### PR TITLE
Add argument registry and unify dry-run behavior

### DIFF
--- a/src/dev_utils/lib_argparse_registry.py
+++ b/src/dev_utils/lib_argparse_registry.py
@@ -1,0 +1,25 @@
+import argparse
+from typing import Callable, List
+
+# Registry storing callbacks that add arguments to a parser
+_registered_callbacks: List[Callable[[argparse.ArgumentParser], None]] = []
+
+
+def register_arguments(callback: Callable[[argparse.ArgumentParser], None]) -> None:
+    """Register a callback that adds arguments to a parser."""
+    _registered_callbacks.append(callback)
+
+
+def build_parser(**kwargs) -> argparse.ArgumentParser:
+    """Create an ArgumentParser with arguments from all registered callbacks."""
+    parser = argparse.ArgumentParser(**kwargs)
+    for cb in _registered_callbacks:
+        cb(parser)
+    return parser
+
+
+def parse_known_args(args=None, **kwargs):
+    """Parse args using a parser built from registered callbacks."""
+    parser = build_parser(**kwargs)
+    return parser.parse_known_args(args)
+

--- a/src/file_utils/dirFileActions.py
+++ b/src/file_utils/dirFileActions.py
@@ -12,6 +12,7 @@ import sys
 
 #from dev_utils import lib_dryrun 
 from dev_utils import *
+from dev_utils.lib_argparse_registry import register_arguments, parse_known_args
 
 # Set up logging
 setup_logging(level=logging.DEBUG)
@@ -39,20 +40,23 @@ def copy_files(file_paths, destination):
         log_out(f"copied: {file_path} => {destination}")
 
 
-def parse_arguments():
-    parser = argparse.ArgumentParser(description="Perform actions on files such as move, delete, and copy.")
-
+def add_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--move', '-m', help="Move files to the specified directory.")
     parser.add_argument('--delete', '-d', action='store_true', help="Delete the specified files.")
     parser.add_argument('--copy', '-c', help="Copy files to the specified directory.")
-    parser.add_argument('files', nargs='*', help="Files to perform actions on.")
-    parser.add_argument('--dry-run', action='store_true', help="Simulate the rename operations without performing them.")
-
     parser.add_argument('--from-file', '-ff', help="Read file names from a file (one per line).")
-    parser.add_argument('files', nargs='*', help="Files to be renamed.")
+    parser.add_argument('files', nargs='*', help="Files to perform actions on.")
+    parser.add_argument('--dry-run', dest='dry_run', action='store_true', default=True,
+                        help="Simulate the rename operations without performing them (default).")
+    parser.add_argument('--exec', '-x', dest='dry_run', action='store_false',
+                        help='Execute the actions on the filesystem.')
 
-    # Add other arguments as necessary
-    args, _ = parser.parse_known_args()
+
+register_arguments(add_args)
+
+
+def parse_arguments():
+    args, _ = parse_known_args(description="Perform actions on files such as move, delete, and copy.")
     return args
 
 


### PR DESCRIPTION
## Summary
- create `lib_argparse_registry` to allow modules to register CLI arguments
- move dirFileActions/renameFiles argument definitions into registry
- make `--exec` flip off `--dry-run`

## Testing
- `PYTHONPATH=src:src/DataTableFunctions:src/utils pytest -q` *(fails: 18 failed, 19 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684886c6cf3c8331b4616707f45a5e52