### PR TITLE
Add email transport support in FILE

### DIFF
--- a/lib_miscDataTableFcns.py
+++ b/lib_miscDataTableFcns.py
@@ -1,0 +1,1 @@
+from src.DataTableFunctions.lib_miscDataTableFcns import *  # noqa: F401,F403

--- a/lib_treeFcns.py
+++ b/lib_treeFcns.py
@@ -1,0 +1,1 @@
+from src.utils.lib_treeFcns import *  # noqa: F401,F403

--- a/src/ai_utils/FILE/README.md
+++ b/src/ai_utils/FILE/README.md
@@ -1,0 +1,39 @@
+# FILE Email Transport
+
+This directory contains utilities for transferring files using different
+communication mechanisms. Transports are pluggable so multiple remote
+endpoints can be configured in `config.yml`.
+
+## Email Transport
+
+`EmailTransport` uses the standard `smtplib` and `imaplib` modules to send
+and receive attachments. Credentials can be provided via the configuration
+file or by environment variables.
+
+### Sending
+
+```python
+from FILE.liaison import send_via_endpoint
+send_via_endpoint(["data.txt"], endpoint="default", subject="Upload")
+```
+
+### Receiving
+
+```python
+from FILE.liaison import receive_from_endpoint
+files = receive_from_endpoint("Upload", endpoint="default")
+```
+
+### MacOS Options
+
+On macOS, Python can interface with:
+
+- **SMTP/IMAP servers** using `smtplib` and `imaplib` (works with Gmail,
+  iCloud, etc.).
+- **Apple Mail** via `osascript` to programmatically compose and send mails.
+- **Gmail API** (`google-api-python-client`) for OAuth based access.
+- **Local sendmail/msmtp** if configured on the system.
+
+Attachments may be added directly or encoded with base64 when embedding into
+mail bodies. Incoming messages can be searched by subject to download
+attachments to the local repository.

--- a/src/ai_utils/FILE/config.yml
+++ b/src/ai_utils/FILE/config.yml
@@ -1,0 +1,12 @@
+endpoints:
+  default:
+    transport: email
+    options:
+      smtp_server: smtp.example.com
+      smtp_port: 465
+      imap_server: imap.example.com
+      imap_port: 993
+      username: user@example.com
+      password_env: FILE_EMAIL_PASSWORD
+      to_addr: dest@example.com
+      subject_prefix: "[FILE]"

--- a/src/ai_utils/FILE/tests/test_email_transport.py
+++ b/src/ai_utils/FILE/tests/test_email_transport.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch, MagicMock
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))  # noqa: E402
+
+from transports import EmailTransport  # pylint: disable=wrong-import-position
+
+
+def test_send_files():
+    with patch('transports.smtplib.SMTP_SSL') as mock_smtp:
+        instance = mock_smtp.return_value.__enter__.return_value
+        transport = EmailTransport(
+            smtp_server='smtp', smtp_port=465, username='u', password='p', to_addr='to'
+        )
+        test_file = os.path.join(os.path.dirname(__file__), '__init__.py')
+        transport.send_files([test_file], subject='sub')
+        instance.login.assert_called_with('u', 'p')
+        instance.send_message.assert_called()
+
+
+def test_receive_files():
+    with patch('transports.imaplib.IMAP4_SSL') as mock_imap:
+        imap_instance = mock_imap.return_value.__enter__.return_value
+        imap_instance.search.return_value = ('OK', [b'1'])
+        imap_instance.fetch.return_value = ('OK', [(b'1', b'')])
+        with patch('transports.BytesParser') as bp:
+            msg = MagicMock()
+            part = MagicMock()
+            part.get_filename.return_value = 'f.txt'
+            part.get_content.return_value = b'hi'
+            msg.iter_attachments.return_value = [part]
+            bp.return_value.parsebytes.return_value = msg
+            transport = EmailTransport(
+                smtp_server='smtp', smtp_port=465, username='u', password='p', to_addr='to'
+            )
+            tmpdir = os.path.dirname(__file__)
+            files = transport.receive_files('sub', tmpdir)
+            assert os.path.join(tmpdir, 'f.txt') in files

--- a/src/ai_utils/FILE/tests/test_file_01.py
+++ b/src/ai_utils/FILE/tests/test_file_01.py
@@ -48,11 +48,8 @@ def test_generate_manifest(tmp_path):
     file2 = tmp_path / "file2.txt"
     file2.write_text("goodbye")
     manifest = liaison.generate_manifest(tmp_path)
-    expected_hashes = {
-        "file1.txt": hashlib.sha256(b"hello world").hexdigest(),
-        "file2.txt": hashlib.sha256(b"goodbye").hexdigest()
-    }
-    assert manifest == expected_hashes
+    assert manifest["file1.txt"]["sha256"] == hashlib.sha256(b"hello world").hexdigest()
+    assert manifest["file2.txt"]["sha256"] == hashlib.sha256(b"goodbye").hexdigest()
 
 def test_compare_manifest(tmp_path):
     # Set up local dir with one good, one outdated, one extra
@@ -100,7 +97,7 @@ def test_pull_files_from_request(tmp_path, monkeypatch):
         yaml.dump(request_manifest, f)
 
     # Monkeypatch log_action to avoid file writes
-    monkeypatch.setattr(liaison, "log_action", lambda f, t: None)
+    monkeypatch.setattr(liaison, "log_action", lambda *a, **k: None)
 
     # Call the function
     liaison.pull_files_from_request(str(request_file))

--- a/src/ai_utils/FILE/transports/__init__.py
+++ b/src/ai_utils/FILE/transports/__init__.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+import base64
+import smtplib
+import imaplib
+from abc import ABC, abstractmethod
+from email.message import EmailMessage
+from email import policy
+from email.parser import BytesParser
+
+
+class Transport(ABC):
+    """Abstract transport class used for sending and receiving files."""
+
+    @abstractmethod
+    def send_files(self, files: list[str], subject: str, body: str = "", **kwargs) -> None:
+        """Send a list of files."""
+
+    @abstractmethod
+    def receive_files(self, subject_filter: str, download_dir: str, **kwargs) -> list[str]:
+        """Retrieve files matching a subject filter and return paths to downloaded files."""
+
+
+class EmailTransport(Transport):
+    """Transport implementation that uses SMTP and IMAP."""
+
+    def __init__(
+        self,
+        smtp_server: str,
+        smtp_port: int,
+        username: str,
+        password: str,
+        to_addr: str,
+        imap_server: str | None = None,
+        imap_port: int = 993,
+        use_ssl: bool = True,
+    ) -> None:
+        self.smtp_server = smtp_server
+        self.smtp_port = smtp_port
+        self.username = username
+        self.password = password
+        self.to_addr = to_addr
+        self.imap_server = imap_server or smtp_server
+        self.imap_port = imap_port
+        self.use_ssl = use_ssl
+
+    def _smtp(self):
+        if self.use_ssl:
+            return smtplib.SMTP_SSL(self.smtp_server, self.smtp_port)
+        smtp = smtplib.SMTP(self.smtp_server, self.smtp_port)
+        smtp.starttls()
+        return smtp
+
+    def send_files(self, files: list[str], subject: str, body: str = "", embed: bool = False) -> None:
+        msg = EmailMessage()
+        msg["From"] = self.username
+        msg["To"] = self.to_addr
+        msg["Subject"] = subject
+        msg.set_content(body or "Sent from FILE")
+
+        for path in files:
+            with open(path, "rb") as f:
+                data = f.read()
+            if embed:
+                b64 = base64.b64encode(data).decode()
+                msg.add_attachment(
+                    b64,
+                    maintype="text",
+                    subtype="plain",
+                    filename=os.path.basename(path) + ".b64",
+                )
+            else:
+                msg.add_attachment(
+                    data,
+                    maintype="application",
+                    subtype="octet-stream",
+                    filename=os.path.basename(path),
+                )
+
+        with self._smtp() as smtp:
+            smtp.login(self.username, self.password)
+            smtp.send_message(msg)
+
+    def receive_files(self, subject_filter: str, download_dir: str) -> list[str]:
+        received: list[str] = []
+        with imaplib.IMAP4_SSL(self.imap_server, self.imap_port) as imap:
+            imap.login(self.username, self.password)
+            imap.select("INBOX")
+            typ, data = imap.search(None, f'SUBJECT "{subject_filter}"')
+            if typ != "OK":
+                return received
+            for num in data[0].split():
+                typ, msg_data = imap.fetch(num, "(RFC822)")
+                if typ != "OK":
+                    continue
+                msg = BytesParser(policy=policy.default).parsebytes(msg_data[0][1])
+                for part in msg.iter_attachments():
+                    filename = part.get_filename()
+                    if not filename:
+                        continue
+                    os.makedirs(download_dir, exist_ok=True)
+                    file_path = os.path.join(download_dir, filename)
+                    with open(file_path, "wb") as fp:
+                        fp.write(part.get_content())
+                    received.append(file_path)
+        return received

--- a/tests/test_Fcn_DataFrames_Equal.py
+++ b/tests/test_Fcn_DataFrames_Equal.py
@@ -1,6 +1,9 @@
+import os
+import sys
 import pytest
 import pandas as pd
-from lib_miscDataTableFcns import dataframes_equal  
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from lib_miscDataTableFcns import dataframes_equal
 
 def test_identical_dataframes():
     df1 = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})

--- a/tests/test_Fcn_FindCircularDependencies.py
+++ b/tests/test_Fcn_FindCircularDependencies.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 
+import os
+import sys
 import pandas as pd
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from lib_treeFcns import Fcn_FindCircularDependencies
-from lib_miscDataTableFcns import dataframes_equal  
+from lib_miscDataTableFcns import dataframes_equal
 
 def test_Fcn_FindCircularDependencies():
     # Test case 1: No circular dependencies


### PR DESCRIPTION
## Summary
- implement new pluggable transport system with `EmailTransport`
- expose helper functions `send_via_endpoint` and `receive_from_endpoint`
- update configuration example and provide README with macOS email options
- add tests for email transport and adjust existing FILE tests
- provide stubs for legacy modules used by tests

## Testing
- `pytest src/ai_utils/FILE/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_684d00672ebc833186d31c37f7ab6ee8