### PR TITLE
Add file type listing and verbose help

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # python_libs
+
+## Utilities
+
+### `findFiles.py`
+Search for files within a directory tree. The script now supports:
+
+- Glob pattern matching (default argument)
+- Substring filtering via `--substr`
+- Regular expression filtering with `--regex`
+- Extension filtering using `--ext`
+- File type filtering via `--type` (e.g., `audio`, `video`)
+- Recursive search using `-r`
+- List available file types with `--list-types`
+- Verbose examples using `--verbose-help`
+
+### `dirFileActions.py`
+Perform basic file operations such as move, copy and delete. Features include:
+
+- Reading file lists from command line, a file (`--from-file`) or piped input
+- Optional glob filtering using `--pattern`
+- Ability to operate on directories when `--include-dirs` is supplied
+- Dry-run mode enabled by default; use `--exec` to apply changes

--- a/src/file_utils/findFiles.py
+++ b/src/file_utils/findFiles.py
@@ -8,10 +8,7 @@
 # Command line parameters don't need to be able to use all the capabilities but can 
 # at least via json config file(s).  
 
-# TODO
-# 0. Use lib_extensions.py to search for files by type
-# 1. find by substring match (-s)
-# 2. find by regex -re
+# Potential future enhancements
 # 3. Use of not for most/all parameters/filters
 # 4. enable pipeline chaining and reading from file
 # 5. find created/modified before/after date/time
@@ -24,18 +21,21 @@
 #     implement reasonably well from a UX standpoint.
 # 12. Default output is std::out
 # 13. Configuration input can be cmd line parameters or json files but not mix both kinds
-# 14. Needs tons of help documentation include lots of real world examples.
+# 14. Extensive documentation with real world examples would be useful.
 
 # Parameters
 # [{--dir | -d} "dir1, dir2, "] : optional, search in specified directories, defaults to "."
-# [--ext "ext1, ext2, "]        : optional, search for items with specified extensions
-# [{--substr | -s} "ss1, ss2, " : optional, search for items that contain specified substrings
-# [--regex "pattern"]           : optional, search for items that match pattern:
+# [--ext "ext1, ext2, "]        : optional, search for items with specified extensions (implemented)
+# [{--substr | -s} "ss1, ss2, " : optional, search for items that contain specified substrings (implemented)
+# [--regex "pattern"]           : optional, search for items that match pattern (implemented)
+# [--type "cat1, cat2"]         : optional, search for known file types such as audio or video
 
 import argparse
 import os
 import fnmatch
 import logging
+import re
+from file_utils.lib_extensions import ExtensionInfo
 #import signal
 #signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
@@ -52,41 +52,130 @@ if not sys.stdout.isatty():
 
 
 @log_function
-def find_files(directory, file_pattern, recursive=False):
+def find_files(
+    directory,
+    file_pattern=None,
+    recursive=False,
+    substrings=None,
+    regex=None,
+    extensions=None,
+    file_types=None,
+):
     """
     Searches for files where the filename exactly matches the given pattern.
 
     :param directory: The directory to search in.
-    :param file_pattern: The complete filename pattern to match.
+    :param file_pattern: A glob-style pattern to match the filename.
     :param recursive: Whether to search recursively in subdirectories.
-    :return: Generator yielding file paths with filenames matching the pattern.
+    :param substrings: Optional list of substrings the filename must contain.
+    :param regex: Optional regular expression that the filename must match.
+    :param extensions: Optional list of file extensions to include.
+    :param file_types: Optional list of file type categories from lib_extensions.
+    :return: Generator yielding file paths matching the provided filters.
     """
 
-    # print(f"Searching in: {directory} for pattern: {file_pattern}")
+    substrings = [s.strip() for s in substrings.split(',')] if isinstance(substrings, str) else (substrings or [])
+    extensions = [e.strip().lower() for e in extensions.split(',')] if isinstance(extensions, str) else (extensions or [])
+    file_types = [t.strip() for t in file_types.split(',')] if isinstance(file_types, str) else (file_types or [])
+
+    extension_info = ExtensionInfo()
+
+    def matches(filename):
+        if file_pattern and not fnmatch.fnmatch(filename, file_pattern):
+            return False
+        if substrings and not any(sub in filename for sub in substrings):
+            return False
+        if regex and not re.search(regex, filename):
+            return False
+        if extensions:
+            lower = filename.lower()
+            if not any(lower.endswith(ext if ext.startswith('.') else f'.{ext}') for ext in extensions):
+                return False
+        if file_types:
+            matched_type = False
+            for ft in file_types:
+                info = extension_info.get(ft)
+                if info and 'regex' in info:
+                    if re.search(info['regex'], filename, re.IGNORECASE):
+                        matched_type = True
+                        break
+            if not matched_type:
+                return False
+        return True
+
     if recursive:
         for root, dirs, files in os.walk(directory):
-            # print(f"Checking directory: {root}")
             for filename in files:
-                if fnmatch.fnmatch(filename, file_pattern):
+                if matches(filename):
                     yield os.path.join(root, filename)
     else:
         for filename in os.listdir(directory):
-            # print(f"Checking file: {filename}")
-            if fnmatch.fnmatch(filename, file_pattern):
+            if matches(filename):
                 yield os.path.join(directory, filename)
+
+
+def list_available_types():
+    """Print known file type categories from :mod:`lib_extensions`."""
+    info = ExtensionInfo()
+    categories = sorted(k for k, v in info.items() if isinstance(v, dict) and 'extensions' in v)
+    print("Available file type categories:")
+    for cat in categories:
+        print(f"  {cat}")
+
+
+def print_verbose_help(parser: argparse.ArgumentParser) -> None:
+    """Print extended usage examples."""
+    parser.print_help()
+    examples = r"""
+Examples:
+  # Recursively search for Python files
+  findFiles.py -r --ext py
+
+  # Find audio files using predefined file type
+  findFiles.py --type audio
+
+  # Find files containing 'test' substring and ending with .txt
+  findFiles.py --substr test --ext txt
+
+  # List available file types
+  findFiles.py --list-types
+"""
+    print(examples)
 
 
 def main():
     parser = argparse.ArgumentParser(description='Search for files matching a pattern.')
-    parser.add_argument('pattern', help='Pattern to search for (e.g., \"*lib*\").')
+    parser.add_argument('pattern', nargs='?', default=None,
+                        help='Glob pattern to search for (e.g., "*lib*")')
     parser.add_argument('directory', nargs='?', default=os.getcwd(),
                         help='Optional directory to start searching from. Defaults to the current directory if not specified.')
     parser.add_argument('-r', '--recursive', action='store_true', help='Search recursively.')
+    parser.add_argument('--substr', '-s', help='Comma-separated substrings to match in filenames.')
+    parser.add_argument('--regex', help='Regular expression the filename must match.')
+    parser.add_argument('--ext', help='Comma-separated list of file extensions to include.')
+    parser.add_argument('--type', help='Comma-separated list of file type categories (e.g., audio, video).')
+    parser.add_argument('--list-types', action='store_true', help='List available file type categories and exit.')
+    parser.add_argument('--verbose-help', action='store_true', help='Show examples for using each option and exit.')
     args, _ = parser.parse_known_args()
-    # args = parser.parse_args()
+
+    if args.list_types:
+        list_available_types()
+        return
+
+    if args.verbose_help:
+        print_verbose_help(parser)
+        return
 
     with log_block("find_files"):
-        for file_path in find_files(args.directory, args.pattern, args.recursive):
+        for file_path in find_files(
+            args.directory,
+            file_pattern=args.pattern,
+            recursive=args.recursive,
+            substrings=args.substr,
+            regex=args.regex,
+            extensions=args.ext,
+            file_types=args.type,
+        ):
             print(file_path)
 
 

--- a/tests/test_findFiles.py
+++ b/tests/test_findFiles.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import importlib
+
+# Ensure src is on sys.path
+sys.path.insert(0, os.path.abspath('src'))
+sys.path.insert(0, os.path.abspath('src/file_utils'))
+
+from file_utils.lib_extensions import ExtensionInfo
+import dev_utils
+from dev_utils import lib_logging
+
+dev_utils.setup_logging = lib_logging.setup_logging
+dev_utils.log_block = lib_logging.log_block
+dev_utils.log_function = lib_logging.log_function
+dev_utils.log_out = lib_logging.log_out
+
+import file_utils.findFiles as findFiles
+
+
+def preload_extension_info():
+    csv_path = os.path.join(os.path.dirname(__file__), '..', 'data', 'extensions.csv')
+    ExtensionInfo(csv_path)
+
+
+def test_find_files_by_audio_type(tmp_path):
+    preload_extension_info()
+    filenames = ['song.mp3', 'sound.wav', 'video.mp4', 'note.txt']
+    for name in filenames:
+        (tmp_path / name).write_text('x')
+
+    results = sorted(os.path.basename(p) for p in findFiles.find_files(
+        str(tmp_path), file_types='Audio'))
+    assert results == ['song.mp3', 'sound.wav']
+
+
+def test_list_available_types(capsys):
+    preload_extension_info()
+    findFiles.list_available_types()
+    out = capsys.readouterr().out
+    assert 'Audio' in out
+    assert 'Video' in out
+
+
+def test_verbose_help_output(capsys):
+    import argparse
+    parser = argparse.ArgumentParser(description='dummy')
+    findFiles.print_verbose_help(parser)
+    out = capsys.readouterr().out
+    assert 'Examples:' in out


### PR DESCRIPTION
## Summary
- document `--list-types` and `--verbose-help`
- clarify TODO comments in utilities
- add `list_available_types` and verbose examples in `findFiles.py`
- test file type lookup and verbose help

## Testing
- `PYTHONPATH=src pytest tests/test_findFiles.py -q`
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'lib_miscDataTableFcns')*
- `PYTHONPATH=src pytest tests/test_dirFileActions.py -q` *(fails: create_test_file not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684cff78ab208331b0a58ed381de7e38