### PR TITLE
Ensure src on path and update helpers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = --ignore=Archive
+log_cli = true
+log_cli_level = DEBUG
+pythonpath = src

--- a/src/file_utils/lib_filters.py
+++ b/src/file_utils/lib_filters.py
@@ -18,6 +18,21 @@ from .fsFilters import (
 class FileSystemFilter(_FileSystemFilter):
     """Subclass adding ``inverse`` support to :meth:`should_include`."""
 
+    def load_extension_data(self):
+        """Load extension metadata via the locally imported helper.
+
+        The :mod:`fsFilters` module defines ``FileSystemFilter`` with a
+        ``load_extension_data`` method that pulls in
+        ``file_utils.lib_extensions.get_extension_data``.  The tests patch
+        ``file_utils.lib_filters.get_extension_data`` expecting our wrapper
+        to honour that stub.  By overriding the method here and delegating
+        to the symbol imported into this module we ensure the patching
+        works as intended and avoid inadvertently loading the heavy YAML
+        configuration during the tests.
+        """
+        if not self.extension_data:
+            self.extension_data = get_extension_data()
+
     def should_include(self, path: Path, base_path: Path | None = None) -> bool:
         include = super().should_include(path, base_path)
         return not include if self.inverse else include

--- a/src/yaml_utils/yaml_validate.py
+++ b/src/yaml_utils/yaml_validate.py
@@ -13,23 +13,32 @@ import sys
 import yaml
 from jsonschema import validate, exceptions
 
-"""
-Validates a Python data object against a schema object.
+"""Validate *data_instance* against *schema_instance*.
 
-Args:
-    data_instance (dict or list): The Python object loaded from a YAML/JSON file.
-    schema_instance (dict): The Python object representing the validation schema.
+The original project exposed a ``validate_data`` helper that returned a
+boolean flag and an optional error message instead of raising
+``jsonschema`` exceptions directly.  Several modules in this kata expect
+that behaviour (for example :mod:`file_utils.lib_extensions`) and the
+tests patch the function accordingly.  The previous implementation
+wrapped :func:`jsonschema.validate` without any error handling which
+caused ``SchemaError`` or ``ValidationError`` exceptions to bubble up and
+abort test execution.  This broke callers that were written to handle a
+``(bool, message)`` return signature.
 
-Returns:
-    bool: True if validation is successful.
-
-Raises:
-    jsonschema.exceptions.ValidationError: If the data does not conform to the schema.
-    jsonschema.exceptions.SchemaError: If the schema itself is invalid.
+To restore the intended API we catch the relevant exceptions and return
+``(False, <message>)`` when validation fails.  A successful validation
+returns ``(True, "")``.  Callers that only care about the boolean value
+can ignore the message while more sophisticated code can report the
+details to the user.
 """
 def validate_data(data_instance, schema_instance):
-    validate(instance=data_instance, schema=schema_instance)
-    return True
+    try:
+        validate(instance=data_instance, schema=schema_instance)
+        return True, ""
+    except exceptions.ValidationError as exc:  # pragma: no cover - thin wrapper
+        return False, exc.message
+    except exceptions.SchemaError as exc:      # pragma: no cover - thin wrapper
+        return False, exc.message
 
 
 """


### PR DESCRIPTION
## Summary
- expose `src` directory to tests via root-level `pytest.ini`
- make `yaml_validate.validate_data` return `(bool, message)` instead of raising
- rework `ExtensionInfo` to seed global cache and add `FileSystemFilter.load_extension_data` wrapper
- restore `renameFiles.py` as a thin wrapper around the external `f2` utility and skip tests when `f2` is absent

## Testing
- `python -m pytest` *(fails: 32 failed, 106 passed, 14 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68901296202483318cbcac21a1b301ae