### PR TITLE
feat: support named config sections in filter loader

### DIFF
--- a/src/file_utils/lib_filters.py
+++ b/src/file_utils/lib_filters.py
@@ -2,6 +2,8 @@
 from datetime import datetime
 from pathlib import Path
 
+from typing import Any, Dict
+
 from .fsFilters import (
     SizeFilter,
     DateFilter as _DateFilter,
@@ -9,10 +11,16 @@ from .fsFilters import (
     FileSystemFilter as _FileSystemFilter,
     apply_config_to_filter,
     get_extension_data,
-    load_config_file,
+    load_config_file as _load_config_file,
     log_info,
     process_filters_pipeline,
 )
+
+
+def load_config_file(config_path: str, config_name: str | None = None) -> Dict[str, Any]:
+    """Wrapper around :func:`fsFilters.load_config_file` for backward compatibility."""
+
+    return _load_config_file(config_path, config_name)
 
 
 class FileSystemFilter(_FileSystemFilter):

--- a/tests/tests_fileUtils/test_fsFilters.py
+++ b/tests/tests_fileUtils/test_fsFilters.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 
 from file_utils.fsFilters import (
     SizeFilter, DateFilter, GitIgnoreFilter, FileSystemFilter,
-    apply_config_to_filter, load_config_file, process_filters_pipeline
+    apply_config_to_filter, process_filters_pipeline, load_config_file
 )
 
 
@@ -389,11 +389,35 @@ class TestConfigurationFunctions:
     def test_load_config_file_success(self):
         """Test successful config file loading."""
         config_data = {'size_gt': '1M', 'file_patterns': ['*.py']}
-        
+
         with patch('builtins.open', mock_open(read_data=yaml.dump(config_data))):
             result = load_config_file('test.yml')
-            
+
         assert result == config_data
+
+    def test_load_config_file_named_section(self):
+        """Test loading a specific configuration section."""
+        config_data = {
+            'dev_cleanup': {'size_gt': '1M'},
+            'other': {'size_gt': '2M'},
+        }
+
+        with patch('builtins.open', mock_open(read_data=yaml.dump(config_data))):
+            result = load_config_file('test.yml', 'dev_cleanup')
+
+        assert result == {'size_gt': '1M'}
+
+    def test_load_config_file_colon_syntax(self):
+        """Test loading configuration using the path:section syntax."""
+        config_data = {
+            'dev_cleanup': {'size_gt': '1M'},
+            'other': {'size_gt': '2M'},
+        }
+
+        with patch('builtins.open', mock_open(read_data=yaml.dump(config_data))):
+            result = load_config_file('test.yml:dev_cleanup')
+
+        assert result == {'size_gt': '1M'}
     
     def test_load_config_file_not_found(self):
         """Test config file loading when file not found."""


### PR DESCRIPTION
## Summary
- Allow `fsFilters.load_config_file` to select a named configuration section via `path:section` or explicit argument
- Update CLI help and documentation to describe new named-section syntax
- Delegate `lib_filters.load_config_file` to the updated implementation and test colon-style usage

## Testing
- `PYTHONPATH=src pytest tests/tests_fileUtils/test_fsFilters.py::TestConfigurationFunctions -q`


------
https://chatgpt.com/codex/tasks/task_e_689bf9d2ce2083319bcb04c1eb5e1b75