### PR TITLE
Fix fsFormat piped file handling and pipeline test script

### DIFF
--- a/src/file_utils/fsFormat.py
+++ b/src/file_utils/fsFormat.py
@@ -223,7 +223,12 @@ class FileSystemFormatter:
                 continue
             
             if path.is_file():
-                if self.show_files and (not fs_filter or fs_filter.should_include(path)):
+                # Always include explicit file inputs. The --files flag controls
+                # whether files discovered while walking directories are added,
+                # but when the user provides file paths directly (e.g. via
+                # stdin pipeline), they should be included regardless so table
+                # formats don't drop all rows.
+                if not fs_filter or fs_filter.should_include(path):
                     all_items.append(FileInfo(path))
             elif path.is_dir():
                 self._collect_from_directory(path, all_items, fs_filter)

--- a/tests/tests_fileUtils/test_pipeline_integration.py
+++ b/tests/tests_fileUtils/test_pipeline_integration.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary
- ensure fsFormat retains explicit file inputs when formatting tables
- add a Python shebang to the pipeline integration test so it runs directly

## Testing
- pytest tests/tests_fileUtils/test_pipeline_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68db447f356c83319f38d78d7cd5406d