### PR TITLE
Fix fsFormat table output for piped files

### DIFF
--- a/src/file_utils/fsFormat.py
+++ b/src/file_utils/fsFormat.py
@@ -221,9 +221,15 @@ class FileSystemFormatter:
             path = Path(path_str)
             if not path.exists():
                 continue
-            
+
             if path.is_file():
-                if self.show_files and (not fs_filter or fs_filter.should_include(path)):
+                # When fsFormat is used in pipelines the incoming paths are
+                # frequently individual files.  Previously these were ignored unless
+                # ``--files`` was provided, yielding empty tables.  Non-tree formats
+                # should surface any files that reach them through stdin or explicit
+                # paths, so honour filters but ignore the tree-centric ``show_files``
+                # toggle.
+                if not fs_filter or fs_filter.should_include(path):
                     all_items.append(FileInfo(path))
             elif path.is_dir():
                 self._collect_from_directory(path, all_items, fs_filter)

--- a/tests/tests_fileUtils/test_pipeline_integration.py
+++ b/tests/tests_fileUtils/test_pipeline_integration.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from __future__ import annotations
 
 import json
@@ -127,3 +128,28 @@ def test_rename_files_format_exec(tmp_path):
 
     renamed = sorted(p.name for p in rename_dir.glob("*.txt"))
     assert renamed == ["renamed_01.txt", "renamed_02.txt"]
+
+
+def test_fsformat_table_includes_piped_files(tmp_path):
+    file_path = tmp_path / "movie.mp4"
+    file_path.write_bytes(b"0" * 10)
+
+    env = _build_env()
+
+    format_proc = _run_module(
+        "file_utils.fsFormat",
+        "--table",
+        "--columns",
+        "name,size,path",
+        input_text=f"{file_path}\n",
+        env=env,
+    )
+
+    assert "movie.mp4" in format_proc.stdout
+    assert "No items to display." not in format_proc.stdout
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary
- allow fsFormat table formatting to include piped file paths without requiring --files
- add a regression test covering table output fed by stdin
- make the pipeline integration test directly executable via a Python shebang and pytest main

## Testing
- pytest tests/tests_fileUtils/test_pipeline_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68db447f356c83319f38d78d7cd5406d