### PR TITLE
Ensure fsFind tests can run as a standalone script

### DIFF
--- a/tests/tests_fileUtils/test_fsFind.py
+++ b/tests/tests_fileUtils/test_fsFind.py
@@ -50,3 +50,9 @@ def test_verbose_help_output(capsys):
     findFiles.print_verbose_help(parser)
     out = capsys.readouterr().out
     assert 'Examples:' in out
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary
- add a __main__ guard to test_fsFind so that running the file directly executes pytest

## Testing
- pytest tests/tests_fileUtils/test_fsFind.py -q

------
https://chatgpt.com/codex/tasks/task_e_68def926fdec8331be6241f1ea01bc99