### PR TITLE
Add reusable Python compile checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,32 @@ Collection of reusable Python utilities, scripts, and helper modules.
 
 See [scripts/README.md](scripts/README.md) for descriptions and usage of the command-line tools in the `scripts/` directory.
 
+## Python byte-compile check
+
+Use the integrated checker to ensure every Python file in the repository can be byte-compiled:
+
+```bash
+PYTHONPATH=src python -m dev_utils.compile_check --recursive .
+```
+
+Key options:
+
+- `paths` (default `.`): files, directories, or glob patterns to inspect.
+- `-r/--recursive` and `--no-recursive`: control directory descent (recursive by default).
+- `-x/--exclude`: additional glob patterns to skip (repeatable). The checker automatically ignores common caches such as `__pycache__/`, `.venv/`, `.pytest_cache/`, and `.mypy_cache/`.
+- `-q/--quiet`: suppress lines for successful files in human-readable output.
+- `--json`: emit structured JSON with `results` (each entry includes `path`, `ok`, `error`, `line`, `column`) and a top-level `all_ok` flag.
+
+Exit code is `0` when every file compiles and `1` otherwise. From Python code you can reuse the logic via:
+
+```python
+from dev_utils import compile_check
+
+results, all_ok = compile_check.run([
+    "src",
+    "tests",
+], excludes=["tmp", "third_party"], recursive=True)
+```
+
+Each `CompileResult` entry exposes the resolved `path`, `ok` status, and optional error details (message plus best-effort line/column numbers when py_compile reports them).
+

--- a/readmes/compile_check_design.md
+++ b/readmes/compile_check_design.md
@@ -1,0 +1,18 @@
+# Python Byte-Compile Check – Design Note
+
+## Inventory of integration points
+- **Scripts directory (`scripts/`)** – Existing developer CLIs are thin wrappers over modules in `src/`. Tools typically live alongside reusable libraries and expose a `main()` that can run via `python -m ...`.
+- **`dev_utils` package** – Hosts shared developer helpers (`lib_logging`, `lib_argparse_registry`, etc.) that other modules import for cross-cutting concerns.
+- **`pytest` test suite** – Primary automation in the repo; no tox/nox configuration found.
+- **Makefile / pre-commit / CI** – No Makefile, `.pre-commit-config.yaml`, tox/nox, or GitHub Actions workflows are present in the repository.
+
+## Options considered
+1. **New utility module in `dev_utils` with CLI entry via `python -m dev_utils.compile_check`**
+   - *Pros*: Reuses the existing argparse registry and logging conventions, keeps functionality importable without side effects, no new top-level script required.
+   - *Cons*: Requires users to know the module path instead of a short alias in `scripts/`.
+2. **Standalone script under `scripts/` invoking a helper in `src/utils`**
+   - *Pros*: Matches the executable helpers listed in `scripts/README.md` and gives a short command name.
+   - *Cons*: Introduces another top-level entry point and duplicates argument parsing unless we thread it through `dev_utils` helpers; less convenient for other Python code to import directly.
+
+## Chosen approach
+Adopt **Option 1**: implement a reusable library function inside `dev_utils` (e.g., `dev_utils.compile_check.run`) and expose a CLI through the same module so it is runnable via `python -m dev_utils.compile_check`. This keeps the checker colocated with other developer utilities, shares the argument registry/logging style, and avoids introducing a new standalone script while remaining easy to import from other tools.

--- a/src/dev_utils/compile_check.py
+++ b/src/dev_utils/compile_check.py
@@ -1,0 +1,283 @@
+"""Python byte-compile checking utilities and CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import py_compile
+import re
+import sys
+from dataclasses import asdict, dataclass
+from glob import glob
+from pathlib import Path
+from typing import Iterator, List, Sequence, Tuple
+
+from dev_utils.lib_argparse_registry import register_arguments, parse_known_args
+from dev_utils.lib_logging import log_error, log_out, setup_logging
+
+setup_logging(level=logging.INFO)
+
+DEFAULT_EXCLUDES: Tuple[str, ...] = (
+    "__pycache__",
+    "*.pyc",
+    "*.pyo",
+    ".git",
+    ".hg",
+    ".svn",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".venv",
+    "venv",
+    "env",
+)
+
+
+@dataclass
+class CompileResult:
+    """Structured outcome for a single source file."""
+
+    path: Path
+    ok: bool
+    error: str | None = None
+    line: int | None = None
+    column: int | None = None
+
+    def to_payload(self) -> dict:
+        data = asdict(self)
+        data["path"] = str(self.path)
+        return data
+
+
+def _looks_like_glob(value: str) -> bool:
+    return any(char in value for char in "*?[]")
+
+
+def _expand_inputs(inputs: Sequence[str | Path]) -> List[Path]:
+    expanded: List[Path] = []
+    for raw in inputs:
+        text = str(raw)
+        if _looks_like_glob(text):
+            matches = [Path(match) for match in glob(text, recursive=True)]
+            if matches:
+                expanded.extend(matches)
+                continue
+        expanded.append(Path(text))
+    return expanded
+
+
+def _extract_location(message_lines: List[str]) -> Tuple[int | None, int | None]:
+    line = None
+    column = None
+    for text in message_lines:
+        match = re.search(r"line (\d+)", text)
+        if match:
+            line = int(match.group(1))
+            break
+    for text in message_lines:
+        caret_index = text.find("^")
+        if caret_index != -1:
+            column = caret_index + 1
+            break
+    return line, column
+
+
+def _is_excluded(path: Path, patterns: Sequence[str]) -> bool:
+    for pattern in patterns:
+        if path.match(pattern) or path.match(f"**/{pattern}"):
+            return True
+        for parent in path.parents:
+            if parent.match(pattern) or parent.match(f"**/{pattern}"):
+                return True
+    return False
+
+
+def _iter_directory(directory: Path, recursive: bool, excludes: Sequence[str]) -> Iterator[Path]:
+    if _is_excluded(directory, excludes):
+        return
+
+    for entry in sorted(directory.iterdir()):
+        if _is_excluded(entry, excludes):
+            continue
+        if entry.is_dir():
+            if recursive:
+                yield from _iter_directory(entry, recursive, excludes)
+            continue
+        if entry.suffix == ".py":
+            yield entry
+
+
+def _iter_python_files(paths: Sequence[str | Path], recursive: bool, excludes: Sequence[str]) -> Iterator[Path]:
+    seen: set[Path] = set()
+    for candidate in _expand_inputs(paths):
+        candidate = candidate.resolve()
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if not candidate.exists():
+            yield candidate  # Missing path handled by caller
+            continue
+        if candidate.is_dir():
+            yield from _iter_directory(candidate, recursive, excludes)
+        elif candidate.suffix == ".py":
+            yield candidate
+
+
+def run(
+    paths: Sequence[str | Path],
+    *,
+    recursive: bool = True,
+    excludes: Sequence[str] | None = None,
+    quiet: bool = False,
+    json_output: bool = False,
+) -> Tuple[List[CompileResult], bool]:
+    """Compile Python files under the provided paths.
+
+    Args:
+        paths: Files, directories, or glob patterns to inspect.
+        recursive: Whether to descend into subdirectories.
+        excludes: Glob patterns to exclude (added to default excludes).
+        quiet: Retained for API compatibility; does not affect returned data.
+        json_output: Included for API parity with the CLI.
+
+    Returns:
+        A tuple of (results list, all_ok flag).
+    """
+
+    exclude_patterns: Tuple[str, ...] = DEFAULT_EXCLUDES + tuple(excludes or ())
+    results: List[CompileResult] = []
+    all_ok = True
+
+    # Prepare canonical list of inputs; handle missing paths explicitly
+    for candidate in _expand_inputs(paths):
+        candidate = candidate.resolve()
+        if not candidate.exists():
+            results.append(CompileResult(path=candidate, ok=False, error="Path not found"))
+            all_ok = False
+
+    files_to_check = list(_iter_python_files(paths, recursive, exclude_patterns))
+
+    for file_path in files_to_check:
+        if not file_path.exists():
+            # Already reported as missing above; skip
+            continue
+        try:
+            py_compile.compile(str(file_path), doraise=True)
+            results.append(CompileResult(path=file_path, ok=True))
+        except py_compile.PyCompileError as exc:
+            all_ok = False
+            message_lines = exc.msg.splitlines()
+            message = message_lines[-1] if message_lines else "Compilation failed"
+            parsed_line, parsed_column = _extract_location(message_lines)
+            line = getattr(exc, "lineno", None) or parsed_line
+            column = getattr(exc, "offset", None) or parsed_column
+            results.append(
+                CompileResult(
+                    path=file_path,
+                    ok=False,
+                    error=message,
+                    line=line,
+                    column=column,
+                )
+            )
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            all_ok = False
+            results.append(CompileResult(path=file_path, ok=False, error=str(exc)))
+
+    # Preserve deterministic ordering by path
+    results.sort(key=lambda result: str(result.path))
+
+    return results, all_ok
+
+
+def add_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["."],
+        help="Files, directories, or glob patterns to check (default: current directory).",
+    )
+    parser.add_argument(
+        "-r",
+        "--recursive",
+        dest="recursive",
+        action="store_true",
+        help="Recurse into subdirectories.",
+    )
+    parser.add_argument(
+        "--no-recursive",
+        dest="recursive",
+        action="store_false",
+        help="Only inspect direct children of provided directories.",
+    )
+    parser.set_defaults(recursive=True)
+    parser.add_argument(
+        "-x",
+        "--exclude",
+        action="append",
+        default=[],
+        help="Glob pattern to exclude (repeatable).",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress OK results in human-readable output.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON results instead of human-readable text.",
+    )
+
+
+register_arguments(add_args)
+
+
+def parse_arguments(args: Sequence[str] | None = None) -> argparse.Namespace:
+    parsed, _ = parse_known_args(args=args, description="Byte-compile Python files using py_compile.")
+    return parsed
+
+
+def _format_result(result: CompileResult) -> str:
+    if result.ok:
+        return f"{result.path}: OK"
+    detail = result.error or "Compilation failed"
+    if result.line is not None:
+        location = f"{result.line}"
+        if result.column is not None:
+            location += f":{result.column}"
+        detail = f"{detail} (line {location})"
+    return f"{result.path}: FAIL — {detail}"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_arguments(argv)
+    results, all_ok = run(
+        args.paths,
+        recursive=args.recursive,
+        excludes=args.exclude,
+        quiet=args.quiet,
+        json_output=args.json,
+    )
+
+    if args.json:
+        payload = {
+            "results": [result.to_payload() for result in results],
+            "all_ok": all_ok,
+        }
+        text = json.dumps(payload, indent=2 if not args.quiet else None)
+        log_out(text)
+    else:
+        for result in results:
+            if result.ok and args.quiet:
+                continue
+            log_out(_format_result(result))
+
+    if not all_ok:
+        log_error("Python byte-compile check failed.")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/tests/test_compile_check.py
+++ b/tests/test_compile_check.py
@@ -1,0 +1,107 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from dev_utils import compile_check
+
+
+def write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def run_cli(args: list[str], repo_root: Path) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    src_path = str((repo_root / "src").resolve())
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = src_path if not existing else f"{src_path}:{existing}"
+    return subprocess.run(
+        [sys.executable, "-m", "dev_utils.compile_check", *args],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def test_run_success(tmp_path: Path) -> None:
+    source = tmp_path / "good.py"
+    write_file(source, "print('ok')\n")
+
+    results, all_ok = compile_check.run([source])
+
+    assert all_ok is True
+    assert any(result.ok and result.path == source.resolve() for result in results)
+
+
+def test_run_syntax_error(tmp_path: Path) -> None:
+    source = tmp_path / "bad.py"
+    write_file(source, "def oops(:\n    pass\n")
+
+    results, all_ok = compile_check.run([source])
+
+    assert all_ok is False
+    failure = next(result for result in results if result.path == source.resolve())
+    assert failure.ok is False
+    assert failure.error is not None and "SyntaxError" in failure.error
+    assert failure.line == 1
+
+
+def test_run_excludes_directory(tmp_path: Path) -> None:
+    included = tmp_path / "pkg" / "included.py"
+    excluded = tmp_path / "pkg" / "skip" / "ignored.py"
+    write_file(included, "value = 1\n")
+    write_file(excluded, "value = 2\n")
+
+    results, all_ok = compile_check.run([tmp_path], excludes=["skip"])
+
+    assert all_ok is True
+    paths = {result.path for result in results}
+    assert included.resolve() in paths
+    assert excluded.resolve() not in paths
+
+
+def test_run_non_recursive(tmp_path: Path) -> None:
+    top_level = tmp_path / "root.py"
+    nested = tmp_path / "nested" / "child.py"
+    write_file(top_level, "print('root')\n")
+    write_file(nested, "print('child')\n")
+
+    results, _ = compile_check.run([tmp_path], recursive=False)
+
+    paths = {result.path for result in results if result.ok}
+    assert top_level.resolve() in paths
+    assert nested.resolve() not in paths
+
+
+def test_cli_json_output(tmp_path: Path) -> None:
+    source = tmp_path / "cli.py"
+    write_file(source, "x = 1\n")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    completed = run_cli(["--json", str(source)], repo_root)
+
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    assert payload["all_ok"] is True
+    assert any(item["path"].endswith("cli.py") and item["ok"] for item in payload["results"])
+
+
+def test_cli_failure_exit_code(tmp_path: Path) -> None:
+    source = tmp_path / "cli_bad.py"
+    write_file(source, "def broken(:\n    pass\n")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    completed = run_cli([str(source)], repo_root)
+
+    assert completed.returncode == 1
+    assert "FAIL" in completed.stdout
+    assert "SyntaxError" in completed.stdout


### PR DESCRIPTION
## Summary
- document integration decisions for adding a repository-wide py_compile check
- add dev_utils.compile_check with reusable run() API and argparse-driven CLI that emits text or JSON
- cover the checker with unit tests and CLI smoke tests and document usage in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ea2c9bcb1083318b51efea52419770