### PR TITLE
Document fsFormat width options and normalize kind mapping

### DIFF
--- a/tests/tests_fileUtils/test_fsFormat_formatting.py
+++ b/tests/tests_fileUtils/test_fsFormat_formatting.py
@@ -90,8 +90,9 @@ def test_table_alignment_with_custom_widths(tmp_path):
 
     lines = [line for line in proc.stdout.splitlines() if "|" in line]
     assert len(lines) >= 3, proc.stdout
-    pipe_positions = {line.index('|') for line in lines}
-    assert len(pipe_positions) == 1
+    pipe_positions = {tuple(idx for idx, ch in enumerate(line) if ch == '|') for line in lines}
+    assert len(pipe_positions) == 1, pipe_positions
+    assert next(iter(pipe_positions)), pipe_positions
 
 
 def test_legacy_output_restores_tree(tmp_path):


### PR DESCRIPTION
## Summary
- normalize extension categories so video, audio, programming, data, and archive kinds map consistently
- document the columns/wrap/width/legacy flags directly in --help, verbose help, and usage examples
- harden the table alignment test to assert shared pipe boundaries instead of brittle string matches

## Testing
- pytest tests/tests_fileUtils/test_fsFormat_formatting.py

------
https://chatgpt.com/codex/tasks/task_e_68eb3b9498dc8331a86eae2aed6c02f4