### PR TITLE
Fix converter CLIs to avoid markdown2 dependency

### DIFF
--- a/src/conversions/__init__.py
+++ b/src/conversions/__init__.py
@@ -1,0 +1,10 @@
+"""Utilities for converting chat histories and documents."""
+
+__all__ = [
+    "chat_history_converter",
+    "doc_converter",
+    "file_converter",
+    "lib_chat_converter",
+    "lib_doc_converter",
+    "conversion_utils",
+]

--- a/src/conversions/file_converter.py
+++ b/src/conversions/file_converter.py
@@ -1,20 +1,24 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-"""
-Universal File Converter (Version 6 - Unified Interface)
-A single command-line tool to convert chat histories and general documents.
-It automatically detects the file type and calls the appropriate conversion logic.
-"""
+"""Unified command line interface for chat and document conversions."""
+
+from __future__ import annotations
 
 import argparse
 import os
-import sys
 import re
+import sys
 
-# Import the callable functions from the specialized scripts
-from chat_history_converter import run_chat_conversion
-from doc_converter import run_doc_conversion
+try:  # pragma: no cover - executed when used as a module
+    from .chat_history_converter import run_chat_conversion
+    from .doc_converter import run_doc_conversion
+except ImportError:  # pragma: no cover - fallback for running as a script
+    CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+    if CURRENT_DIR not in sys.path:
+        sys.path.insert(0, CURRENT_DIR)
+    from chat_history_converter import run_chat_conversion  # type: ignore
+    from doc_converter import run_doc_conversion  # type: ignore
 
 
 """
@@ -41,58 +45,132 @@ def is_chat_file(file_path):
 """
 The main dispatcher function.
 """
-def main():
+EXAMPLES_TEXT = """Examples:
+  python -m conversions.file_converter meeting.md
+  python -m conversions.file_converter transcript.txt -f json -o out.json
+  python -m conversions.file_converter notes.yml --no-toc
+  python -m conversions.file_converter chat.md --analyze
+"""
+
+
+VERBOSE_TEXT = """Detailed option reference:
+  input_file           File to convert. Chat detection runs automatically.
+  -o, --output         Destination file. Defaults to <input>.<format>.
+  -f, --format         Output format: html, md, json or yml. Defaults to html.
+  --force              Overwrite existing output files.
+  --analyze            (Chat) Print statistics instead of writing a file.
+  --no-toc             (Document) Disable Table of Contents in HTML output.
+  --help-examples      Display real-world command examples.
+  --help-verbose       Display this extended description.
+  -h, --help           Display the standard argument help screen.
+"""
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Construct and return the CLI argument parser."""
+
     parser = argparse.ArgumentParser(
         description="A unified tool to convert chat histories and documents.",
         formatter_class=argparse.RawTextHelpFormatter,
-        add_help=False
+        add_help=False,
     )
-    # --- Universal Arguments ---
-    parser.add_argument("input_file", help="Path to the input file.")
-    parser.add_argument("-o", "--output", help="Path for the output file.")
-    parser.add_argument("-f", "--format", choices=['json', 'yml', 'md', 'html'], help="Output format.")
-    parser.add_argument("--force", action="store_true", help="Force overwrite of output file.")
+    parser.add_argument(
+        "input_file",
+        help="Path to the input file (chat or document).",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Path for the output file. Defaults to the input name + format.",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=["json", "yml", "md", "html"],
+        help="Desired output format (html/md/json/yml).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force overwrite of the output file if it already exists.",
+    )
+    chat_group = parser.add_argument_group("Chat-Specific Options")
+    chat_group.add_argument(
+        "--analyze",
+        action="store_true",
+        help="Display chat statistics instead of converting.",
+    )
+    doc_group = parser.add_argument_group("Document-Specific Options")
+    doc_group.add_argument(
+        "--no-toc",
+        action="store_true",
+        help="Disable Table of Contents generation in HTML output.",
+    )
+    parser.add_argument(
+        "--help-examples",
+        action="store_true",
+        help="Show usage examples and exit.",
+    )
+    parser.add_argument(
+        "--help-verbose",
+        action="store_true",
+        help="Show an extended description of each option and exit.",
+    )
+    parser.add_argument(
+        "-h",
+        "--help",
+        "-?",
+        "--Help",
+        action="help",
+        help="Show this help message and exit.",
+    )
+    return parser
 
-    # --- Chat-Specific Arguments ---
-    chat_group = parser.add_argument_group('Chat-Specific Options')
-    chat_group.add_argument("--analyze", action="store_true", help="Display chat statistics instead of converting.")
 
-    # --- Document-Specific Arguments ---
-    doc_group = parser.add_argument_group('Document-Specific Options')
-    doc_group.add_argument("--no-toc", action="store_true", help="Disable Table of Contents in HTML output.")
+def main(argv: list[str] | None = None) -> int:
+    """Entry point used by both the console script and unit tests."""
 
-    # --- Help ---
-    parser.add_argument("-h", "--help", "-?", "--Help", action="help", help="Show this help message and exit.")
+    argv = list(sys.argv[1:] if argv is None else argv)
 
-    args = parser.parse_args()
+    if "--help-examples" in argv:
+        print(EXAMPLES_TEXT.strip())
+        return 0
+    if "--help-verbose" in argv:
+        print(VERBOSE_TEXT.strip())
+        return 0
+
+    parser = create_parser()
+    args = parser.parse_args(argv)
 
     if not os.path.exists(args.input_file):
         print(f"Error: Input file not found at '{args.input_file}'", file=sys.stderr)
-        sys.exit(1)
+        return 1
 
-    # --- Set sensible defaults if not provided ---
     if not args.format and args.output:
         args.format = os.path.splitext(args.output)[1].lower().replace('.', '')
     elif not args.format:
-        args.format = 'html' # Default to HTML if no other info
+        args.format = 'html'
 
     if not args.output:
         base_name = os.path.splitext(args.input_file)[0]
         args.output = f"{base_name}.{args.format}"
 
     if os.path.exists(args.output) and not args.force:
-        print(f"Error: Output file '{args.output}' already exists. Use --force to overwrite.", file=sys.stderr)
-        sys.exit(1)
+        print(
+            f"Error: Output file '{args.output}' already exists. Use --force to overwrite.",
+            file=sys.stderr,
+        )
+        return 1
 
-    # --- The Dispatcher Logic ---
     if is_chat_file(args.input_file):
         print("Chat file detected. Using chat history converter...")
         run_chat_conversion(args)
     else:
         print("Document file detected. Using document converter...")
         run_doc_conversion(args)
+    return 0
 
 
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__":  # pragma: no cover - manual execution hook
+    raise SystemExit(main())
 

--- a/src/conversions/lib_chat_converter.py
+++ b/src/conversions/lib_chat_converter.py
@@ -1,8 +1,19 @@
 # lib_chat_converter.py
+from __future__ import annotations
+
 import re
-import markdown2
 from datetime import datetime
-import conversion_utils as utils
+
+try:  # pragma: no cover - executed during normal operation
+    from . import conversion_utils as utils
+except ImportError:  # pragma: no cover - fallback for running as script
+    import os
+    import sys
+
+    CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+    if CURRENT_DIR not in sys.path:
+        sys.path.insert(0, CURRENT_DIR)
+    import conversion_utils as utils  # type: ignore
 
 """
 Parses a Markdown file formatted for chat logs, expecting 'role: content'
@@ -84,7 +95,9 @@ Returns:
 """
 def to_html_chat(metadata, messages, css_content):
     title = metadata.get('title', 'Chat History')
-    markdowner = markdown2.Markdown(extras=["tables", "fenced-code-blocks", "strike"])
+    markdowner = utils.get_markdown_converter(
+        extras=["tables", "fenced-code-blocks", "strike"]
+    )
 
     message_html_parts = []
     for msg in messages:

--- a/src/conversions/lib_doc_converter.py
+++ b/src/conversions/lib_doc_converter.py
@@ -1,7 +1,16 @@
 # lib_doc_converter.py
-import markdown2
-import conversion_utils as utils
-import yaml
+from __future__ import annotations
+
+try:  # pragma: no cover - executed during normal operation
+    from . import conversion_utils as utils
+except ImportError:  # pragma: no cover - fallback when run as a script
+    import os
+    import sys
+
+    CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+    if CURRENT_DIR not in sys.path:
+        sys.path.insert(0, CURRENT_DIR)
+    import conversion_utils as utils  # type: ignore
 
 """
 * Recursively converts a Python object (from YAML/JSON) into an HTML string
@@ -93,7 +102,9 @@ def to_html_document(metadata, content, css_content, include_toc=True):
 
         if isinstance(doc, str): # Handle Markdown content
             # (Logic for markdown remains the same)
-            markdowner = markdown2.Markdown(extras=["toc", "tables", "fenced-code-blocks", "strike"])
+            markdowner = utils.get_markdown_converter(
+                extras=["toc", "tables", "fenced-code-blocks", "strike"]
+            )
             html_part = markdowner.convert(doc)
             final_html_content += f'<div class="content">{html_part}</div>'
         elif isinstance(doc, dict): # Handle structured data

--- a/tests/test_converters/test_converters.py
+++ b/tests/test_converters/test_converters.py
@@ -1,0 +1,129 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+SRC_DIR = ROOT_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from conversions import chat_history_converter, doc_converter, file_converter
+
+
+def _create_chat_file(tmp_path: Path) -> Path:
+    chat_text = """---
+title: Demo Chat
+---
+user: Hello there!
+assistant: Hi!
+"""
+    chat_file = tmp_path / "chat.md"
+    chat_file.write_text(chat_text)
+    return chat_file
+
+
+def _create_doc_file(tmp_path: Path) -> Path:
+    doc_text = """# Sample Document\n\nThis document is used in automated tests."""
+    doc_file = tmp_path / "document.md"
+    doc_file.write_text(doc_text)
+    return doc_file
+
+
+def test_chat_history_conversion_creates_html(tmp_path):
+    chat_file = _create_chat_file(tmp_path)
+    output_file = tmp_path / "chat.html"
+    args = SimpleNamespace(
+        input_file=str(chat_file),
+        output=str(output_file),
+        format="html",
+        analyze=False,
+    )
+
+    chat_history_converter.run_chat_conversion(args)
+
+    html_output = output_file.read_text()
+    assert "Demo Chat" in html_output
+    assert "Hello there" in html_output
+
+
+def test_doc_conversion_creates_html(tmp_path):
+    doc_file = _create_doc_file(tmp_path)
+    output_file = tmp_path / "document.html"
+    args = SimpleNamespace(
+        input_file=str(doc_file),
+        output=str(output_file),
+        format="html",
+        no_toc=False,
+    )
+
+    doc_converter.run_doc_conversion(args)
+
+    html_output = output_file.read_text()
+    assert "Sample Document" in html_output
+    assert "<!DOCTYPE html>" in html_output
+
+
+def test_file_converter_dispatches_chat(tmp_path):
+    chat_file = _create_chat_file(tmp_path)
+    output_file = tmp_path / "chat.html"
+
+    exit_code = file_converter.main([
+        str(chat_file),
+        "-o",
+        str(output_file),
+        "-f",
+        "html",
+    ])
+
+    assert exit_code == 0
+    assert output_file.exists()
+
+
+def test_file_converter_dispatches_document(tmp_path):
+    doc_file = _create_doc_file(tmp_path)
+    output_file = tmp_path / "document.html"
+
+    exit_code = file_converter.main([
+        str(doc_file),
+        "-o",
+        str(output_file),
+        "-f",
+        "html",
+        "--no-toc",
+    ])
+
+    assert exit_code == 0
+    assert output_file.exists()
+
+
+def test_help_variants_work():
+    commands = [
+        ("conversions.chat_history_converter", "--help", "usage"),
+        ("conversions.chat_history_converter", "--help-examples", "Examples:"),
+        ("conversions.chat_history_converter", "--help-verbose", "Detailed option reference"),
+        ("conversions.doc_converter", "--help", "usage"),
+        ("conversions.doc_converter", "--help-examples", "Examples:"),
+        ("conversions.doc_converter", "--help-verbose", "Detailed option reference"),
+        ("conversions.file_converter", "--help", "usage"),
+        ("conversions.file_converter", "--help-examples", "Examples:"),
+        ("conversions.file_converter", "--help-verbose", "Detailed option reference"),
+    ]
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(SRC_DIR)] + ([env["PYTHONPATH"]] if "PYTHONPATH" in env else [])
+    )
+
+    for module, flag, expected_text in commands:
+        result = subprocess.run(
+            [sys.executable, "-m", module, flag],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert expected_text in result.stdout
+


### PR DESCRIPTION
## Summary
- add a lightweight Markdown conversion fallback so chat/doc converters no longer require markdown2
- refactor the chat, document, and unified converters into a package-friendly CLI with enhanced help output
- cover the converters with pytest cases that exercise conversions and the new help/verbose flags

## Testing
- pytest tests/test_converters -q

------
https://chatgpt.com/codex/tasks/task_e_68f687ae55848331b3684465b07aa958