### PR TITLE
Add markdown fallback for converters and expand CLI help

### DIFF
--- a/src/conversions/__init__.py
+++ b/src/conversions/__init__.py
@@ -1,0 +1,19 @@
+"""Utilities for converting chat histories and documents."""
+
+from . import chat_history_converter
+from . import doc_converter
+from . import file_converter
+from . import lib_chat_converter
+from . import lib_doc_converter
+from . import conversion_utils
+from . import markdown_adapters
+
+__all__ = [
+    "chat_history_converter",
+    "doc_converter",
+    "file_converter",
+    "lib_chat_converter",
+    "lib_doc_converter",
+    "conversion_utils",
+    "markdown_adapters",
+]

--- a/src/conversions/chat_history_converter.py
+++ b/src/conversions/chat_history_converter.py
@@ -10,8 +10,14 @@ This script is intended to be called by a master dispatcher.
 import argparse
 import os
 import sys
-import lib_chat_converter as converter
-import conversion_utils as utils
+import textwrap
+
+try:  # pragma: no cover - import shim
+    from . import lib_chat_converter as converter  # type: ignore
+    from . import conversion_utils as utils  # type: ignore
+except ImportError:  # pragma: no cover - script execution path
+    import lib_chat_converter as converter  # type: ignore
+    import conversion_utils as utils  # type: ignore
 
 # Default CSS for HTML Output
 DEFAULT_CSS = """
@@ -96,13 +102,89 @@ def run_chat_conversion(args):
 """
 Main entry point for running this script directly.
 """
-def main():
-    parser = argparse.ArgumentParser(description="Standalone Chat History Converter.")
-    parser.add_argument("input_file")
-    parser.add_argument("-o", "--output")
-    parser.add_argument("-f", "--format")
-    parser.add_argument("--analyze", action="store_true")
-    args = parser.parse_args()
+HELP_EXAMPLES = textwrap.dedent(
+    """
+    chat_history_converter.py conversation.md --format html
+    chat_history_converter.py transcript.json -f md -o output/transcript.md
+    chat_history_converter.py sample.yml --analyze
+    """
+)
+
+HELP_VERBOSE = textwrap.dedent(
+    """
+    This tool reads a chat transcript stored as Markdown, JSON, or YAML and
+    converts it into HTML, Markdown, JSON, or YAML.  When ``--analyze`` is
+    supplied the conversion step is skipped and chat statistics are printed
+    instead.
+
+    Input discovery:
+      * Markdown files are parsed for ``role: message`` pairs.
+      * JSON and YAML inputs must contain ``metadata`` and ``messages`` keys.
+
+    Output defaults:
+      * When no ``--format`` is specified HTML is produced.
+      * The output path defaults to ``<input>.<format>`` when ``--output`` is
+        omitted.
+    """
+)
+
+
+def _register_help_actions(parser: argparse.ArgumentParser) -> None:
+    class _ExamplesAction(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            parser.print_help()
+            print("\nExamples:\n" + HELP_EXAMPLES)
+            parser.exit()
+
+    class _VerboseAction(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            parser.print_help()
+            print("\nDetailed information:\n" + HELP_VERBOSE)
+            parser.exit()
+
+    parser.add_argument(
+        "--help-examples",
+        action=_ExamplesAction,
+        nargs=0,
+        help="Show example invocations and exit.",
+    )
+    parser.add_argument(
+        "--help-verbose",
+        action=_VerboseAction,
+        nargs=0,
+        help="Show detailed usage notes and exit.",
+    )
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Standalone Chat History Converter.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("input_file", help="Path to the chat transcript to convert.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Destination path for the converted document. Defaults to <input>.<format>.",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=["html", "md", "json", "yml"],
+        help="Output format for the conversion.",
+    )
+    parser.add_argument(
+        "--analyze",
+        action="store_true",
+        help="Print chat statistics instead of writing a converted file.",
+    )
+    _register_help_actions(parser)
+    return parser
+
+
+def main(argv=None):
+    parser = create_parser()
+    args = parser.parse_args(argv)
 
     # Simple defaulting for standalone mode
     if not args.format and args.output:

--- a/src/conversions/file_converter.py
+++ b/src/conversions/file_converter.py
@@ -11,10 +11,15 @@ import argparse
 import os
 import sys
 import re
+import textwrap
 
 # Import the callable functions from the specialized scripts
-from chat_history_converter import run_chat_conversion
-from doc_converter import run_doc_conversion
+try:  # pragma: no cover - import shim
+    from .chat_history_converter import run_chat_conversion  # type: ignore
+    from .doc_converter import run_doc_conversion  # type: ignore
+except ImportError:  # pragma: no cover - script execution path
+    from chat_history_converter import run_chat_conversion  # type: ignore
+    from doc_converter import run_doc_conversion  # type: ignore
 
 
 """
@@ -41,30 +46,85 @@ def is_chat_file(file_path):
 """
 The main dispatcher function.
 """
-def main():
+HELP_EXAMPLES = textwrap.dedent(
+    """
+    file_converter.py chat.md --format json
+    file_converter.py transcript.yml --analyze
+    file_converter.py handbook.md -f html -o build/handbook.html --force
+    """
+)
+
+HELP_VERBOSE = textwrap.dedent(
+    """
+    The universal converter inspects the input file to decide whether the chat
+    or the document pipeline should process it.  Chat detection looks for role
+    prefixes such as ``user:`` or ``assistant:`` within the first couple of
+    kilobytes of the file.  All options accepted by the specialised converters
+    are available here as well.
+
+    Default behaviour:
+      * The output format defaults to HTML and can be inferred from the output
+        file extension when supplied.
+      * The output path defaults to ``<input>.<format>`` when omitted.
+      * ``--force`` overrides the safety check that prevents overwriting
+        existing files.
+    """
+)
+
+
+def _register_help_actions(parser: argparse.ArgumentParser) -> None:
+    class _ExamplesAction(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            parser.print_help()
+            print("\nExamples:\n" + HELP_EXAMPLES)
+            parser.exit()
+
+    class _VerboseAction(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            parser.print_help()
+            print("\nDetailed information:\n" + HELP_VERBOSE)
+            parser.exit()
+
+    parser.add_argument(
+        "--help-examples",
+        action=_ExamplesAction,
+        nargs=0,
+        help="Show example invocations and exit.",
+    )
+    parser.add_argument(
+        "--help-verbose",
+        action=_VerboseAction,
+        nargs=0,
+        help="Show detailed usage notes and exit.",
+    )
+
+
+def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="A unified tool to convert chat histories and documents.",
         formatter_class=argparse.RawTextHelpFormatter,
-        add_help=False
+        add_help=False,
     )
-    # --- Universal Arguments ---
+
     parser.add_argument("input_file", help="Path to the input file.")
     parser.add_argument("-o", "--output", help="Path for the output file.")
     parser.add_argument("-f", "--format", choices=['json', 'yml', 'md', 'html'], help="Output format.")
     parser.add_argument("--force", action="store_true", help="Force overwrite of output file.")
 
-    # --- Chat-Specific Arguments ---
     chat_group = parser.add_argument_group('Chat-Specific Options')
     chat_group.add_argument("--analyze", action="store_true", help="Display chat statistics instead of converting.")
 
-    # --- Document-Specific Arguments ---
     doc_group = parser.add_argument_group('Document-Specific Options')
     doc_group.add_argument("--no-toc", action="store_true", help="Disable Table of Contents in HTML output.")
 
-    # --- Help ---
     parser.add_argument("-h", "--help", "-?", "--Help", action="help", help="Show this help message and exit.")
+    _register_help_actions(parser)
+    return parser
 
-    args = parser.parse_args()
+
+def main(argv=None):
+    parser = create_parser()
+    args = parser.parse_args(argv)
 
     if not os.path.exists(args.input_file):
         print(f"Error: Input file not found at '{args.input_file}'", file=sys.stderr)

--- a/src/conversions/lib_chat_converter.py
+++ b/src/conversions/lib_chat_converter.py
@@ -1,8 +1,13 @@
 # lib_chat_converter.py
 import re
-import markdown2
 from datetime import datetime
-import conversion_utils as utils
+
+try:  # pragma: no cover - import shim
+    from . import conversion_utils as utils  # type: ignore
+    from .markdown_adapters import create_markdowner  # type: ignore
+except ImportError:  # pragma: no cover - script execution path
+    import conversion_utils as utils  # type: ignore
+    from markdown_adapters import create_markdowner  # type: ignore
 
 """
 Parses a Markdown file formatted for chat logs, expecting 'role: content'
@@ -84,7 +89,7 @@ Returns:
 """
 def to_html_chat(metadata, messages, css_content):
     title = metadata.get('title', 'Chat History')
-    markdowner = markdown2.Markdown(extras=["tables", "fenced-code-blocks", "strike"])
+    markdowner = create_markdowner(["tables", "fenced-code-blocks", "strike"])
 
     message_html_parts = []
     for msg in messages:

--- a/src/conversions/lib_doc_converter.py
+++ b/src/conversions/lib_doc_converter.py
@@ -1,7 +1,12 @@
 # lib_doc_converter.py
-import markdown2
-import conversion_utils as utils
 import yaml
+
+try:  # pragma: no cover - import shim
+    from . import conversion_utils as utils  # type: ignore
+    from .markdown_adapters import create_markdowner  # type: ignore
+except ImportError:  # pragma: no cover - script execution path
+    import conversion_utils as utils  # type: ignore
+    from markdown_adapters import create_markdowner  # type: ignore
 
 """
 * Recursively converts a Python object (from YAML/JSON) into an HTML string
@@ -93,7 +98,7 @@ def to_html_document(metadata, content, css_content, include_toc=True):
 
         if isinstance(doc, str): # Handle Markdown content
             # (Logic for markdown remains the same)
-            markdowner = markdown2.Markdown(extras=["toc", "tables", "fenced-code-blocks", "strike"])
+            markdowner = create_markdowner(["toc", "tables", "fenced-code-blocks", "strike"])
             html_part = markdowner.convert(doc)
             final_html_content += f'<div class="content">{html_part}</div>'
         elif isinstance(doc, dict): # Handle structured data

--- a/src/conversions/markdown_adapters.py
+++ b/src/conversions/markdown_adapters.py
@@ -1,0 +1,96 @@
+"""Utility helpers for obtaining a Markdown converter.
+
+The original converter scripts relied on the third-party :mod:`markdown2`
+package.  The execution environment used for the kata, however, does not ship
+with that dependency which previously resulted in ``ModuleNotFoundError``
+failures when importing the converter libraries.  This module provides a small
+adapter layer that attempts to use ``markdown2`` when available, gracefully
+falls back to the widely used ``markdown`` package, and finally uses a very
+small HTML escaping implementation when no Markdown engine can be imported.
+
+The goal is not to be feature complete but to provide deterministic behaviour
+and keep the public interface that the surrounding modules expect: an object
+exposing a :py:meth:`convert` method.
+"""
+from __future__ import annotations
+
+import html
+import importlib
+import os
+from typing import Iterable, List
+
+_PLAIN_BACKEND_SENTINEL = "plain"
+
+
+def _import_optional(name: str):
+    """Attempt to import *name* and return ``None`` on failure."""
+
+    try:
+        return importlib.import_module(name)
+    except ModuleNotFoundError:
+        return None
+
+
+class _PlainMarkdowner:
+    """Minimal HTML renderer used when no Markdown library is available."""
+
+    def __init__(self, extras: Iterable[str] | None = None) -> None:
+        self.extras = list(extras or [])
+
+    def convert(self, text: str) -> str:  # pragma: no cover - trivial
+        """Return a very small HTML representation of *text*.
+
+        The implementation keeps formatting extremely simple: HTML special
+        characters are escaped, blank lines denote paragraphs, and newlines are
+        converted to ``<br />`` tags.  This keeps the rendered output readable
+        even without a full Markdown engine.
+        """
+
+        escaped = html.escape(text)
+        paragraphs = [segment.replace("\n", "<br />") for segment in escaped.split("\n\n")]
+        return "".join(f"<p>{para}</p>" for para in paragraphs if para)
+
+
+class _MarkdownWrapper:
+    """Adapt the :mod:`markdown` package to the ``markdown2`` style interface."""
+
+    def __init__(self, markdown_module, extensions: List[str]):
+        self._markdown = markdown_module
+        self._extensions = extensions
+
+    def convert(self, text: str) -> str:  # pragma: no cover - thin wrapper
+        return self._markdown.markdown(text, extensions=self._extensions, output_format="html5")
+
+
+def _extras_to_markdown_extensions(extras: Iterable[str]) -> List[str]:
+    """Translate ``markdown2`` extras into :mod:`markdown` extensions."""
+
+    mapping = {
+        "tables": "tables",
+        "fenced-code-blocks": "fenced_code",
+        "strike": "strikeout",
+        "toc": "toc",
+    }
+    return [mapping[extra] for extra in extras if extra in mapping]
+
+
+def create_markdowner(extras: Iterable[str] | None = None):
+    """Return an object providing a ``convert`` method for Markdown strings."""
+
+    extras = list(extras or [])
+    backend_override = os.environ.get("CONVERTERS_MARKDOWN_BACKEND", "").lower().strip()
+
+    if backend_override != _PLAIN_BACKEND_SENTINEL:
+        markdown2_module = _import_optional("markdown2")
+        if markdown2_module is not None:
+            return markdown2_module.Markdown(extras=extras)
+
+        markdown_module = _import_optional("markdown")
+        if markdown_module is not None:
+            extensions = _extras_to_markdown_extensions(extras)
+            return _MarkdownWrapper(markdown_module, extensions)
+
+    return _PlainMarkdowner(extras)
+
+
+__all__ = ["create_markdowner"]

--- a/tests/test_converters/conftest.py
+++ b/tests/test_converters/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parents[2] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))

--- a/tests/test_converters/test_chat_converter.py
+++ b/tests/test_converters/test_chat_converter.py
@@ -1,0 +1,74 @@
+import argparse
+
+import pytest
+
+from conversions import chat_history_converter
+from conversions import lib_chat_converter
+
+
+def test_to_html_chat_plain_backend(monkeypatch):
+    monkeypatch.setenv("CONVERTERS_MARKDOWN_BACKEND", "plain")
+    metadata = {"title": "Sample"}
+    messages = [
+        {"role": "user", "content": "Hello **world**"},
+        {"role": "assistant", "content": "General Kenobi"},
+    ]
+
+    html = lib_chat_converter.to_html_chat(metadata, messages, "body {}")
+
+    assert "<div class=\"message user\">" in html
+    assert "Hello **world**" in html
+    assert "<p>General Kenobi</p>" in html
+
+
+def test_analyze_chat_counts():
+    messages = [
+        {"role": "user", "content": "Hi"},
+        {"role": "assistant", "content": "Hello"},
+        {"role": "system", "content": "Rules"},
+        {"role": "user", "content": "Bye"},
+    ]
+
+    stats = lib_chat_converter.analyze_chat(messages)
+    assert stats == {
+        "total_messages": 4,
+        "user_messages": 2,
+        "assistant_messages": 1,
+        "system_prompts": 1,
+    }
+
+
+def test_run_chat_conversion_writes_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("CONVERTERS_MARKDOWN_BACKEND", "plain")
+    input_file = tmp_path / "conversation.md"
+    input_file.write_text("user: Hi\nassistant: Hello")
+    output_file = tmp_path / "conversation.html"
+
+    args = argparse.Namespace(
+        input_file=str(input_file),
+        output=str(output_file),
+        format="html",
+        analyze=False,
+    )
+
+    chat_history_converter.run_chat_conversion(args)
+
+    assert output_file.exists()
+    written = output_file.read_text()
+    assert "Chat History" in written
+
+
+def test_help_actions_print_examples_and_verbose(capsys):
+    parser = chat_history_converter.create_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--help-examples"])
+    output = capsys.readouterr().out
+    assert "Examples:" in output
+    assert "chat_history_converter.py" in output
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--help-verbose"])
+    verbose_output = capsys.readouterr().out
+    assert "Detailed information:" in verbose_output
+    assert "chat transcript" in verbose_output

--- a/tests/test_converters/test_doc_converter.py
+++ b/tests/test_converters/test_doc_converter.py
@@ -1,0 +1,54 @@
+import argparse
+
+import pytest
+
+from conversions import doc_converter
+from conversions import lib_doc_converter
+
+
+def test_to_html_document_plain_backend(monkeypatch):
+    monkeypatch.setenv("CONVERTERS_MARKDOWN_BACKEND", "plain")
+    metadata = {"title": "Document"}
+    content = "# Heading\n\nSome text."
+
+    html = lib_doc_converter.to_html_document(metadata, content, "body {}", include_toc=True)
+
+    assert "<div class=\"content\">" in html
+    assert "# Heading" in html  # rendered literally by the plain backend
+    assert "Some text." in html
+
+
+def test_run_doc_conversion_writes_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("CONVERTERS_MARKDOWN_BACKEND", "plain")
+    input_file = tmp_path / "document.md"
+    input_file.write_text("# Title\n\nContent")
+    output_file = tmp_path / "document.html"
+
+    args = argparse.Namespace(
+        input_file=str(input_file),
+        output=str(output_file),
+        format="html",
+        no_toc=False,
+    )
+
+    doc_converter.run_doc_conversion(args)
+
+    assert output_file.exists()
+    written = output_file.read_text()
+    assert "Document" in written or "Title" in written
+
+
+def test_help_actions_print_examples_and_verbose(capsys):
+    parser = doc_converter.create_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--help-examples"])
+    output = capsys.readouterr().out
+    assert "Examples:" in output
+    assert "doc_converter.py" in output
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--help-verbose"])
+    verbose_output = capsys.readouterr().out
+    assert "Detailed information:" in verbose_output
+    assert "document converter" in verbose_output.lower()

--- a/tests/test_converters/test_file_converter.py
+++ b/tests/test_converters/test_file_converter.py
@@ -1,0 +1,79 @@
+import argparse
+
+import pytest
+
+from conversions import file_converter
+
+
+def test_is_chat_file_detects_chat(tmp_path):
+    chat_file = tmp_path / "chat.md"
+    chat_file.write_text("user: hi\nassistant: hello")
+
+    assert file_converter.is_chat_file(str(chat_file)) is True
+
+
+def test_is_chat_file_detects_document(tmp_path):
+    doc_file = tmp_path / "doc.md"
+    doc_file.write_text("# Heading\n\nSome text")
+
+    assert file_converter.is_chat_file(str(doc_file)) is False
+
+
+def test_help_actions_print_examples_and_verbose(capsys):
+    parser = file_converter.create_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--help-examples"])
+    output = capsys.readouterr().out
+    assert "Examples:" in output
+    assert "file_converter.py" in output
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--help-verbose"])
+    verbose_output = capsys.readouterr().out
+    assert "Detailed information:" in verbose_output
+    assert "universal converter" in verbose_output.lower()
+
+
+def test_main_dispatches_to_chat(monkeypatch, tmp_path):
+    chat_file = tmp_path / "chat.md"
+    chat_file.write_text("user: hi\nassistant: hello")
+    output_file = tmp_path / "chat.html"
+
+    called = {}
+
+    def fake_chat(args):
+        called['chat'] = args
+
+    def fake_doc(args):
+        called['doc'] = args
+
+    monkeypatch.setattr(file_converter, "run_chat_conversion", fake_chat)
+    monkeypatch.setattr(file_converter, "run_doc_conversion", fake_doc)
+
+    file_converter.main([str(chat_file), "-o", str(output_file), "-f", "html", "--force"])
+
+    assert 'chat' in called
+    assert 'doc' not in called
+
+
+def test_main_dispatches_to_doc(monkeypatch, tmp_path):
+    doc_file = tmp_path / "doc.md"
+    doc_file.write_text("# Heading\n\nSome text")
+    output_file = tmp_path / "doc.html"
+
+    called = {}
+
+    def fake_chat(args):
+        called['chat'] = args
+
+    def fake_doc(args):
+        called['doc'] = args
+
+    monkeypatch.setattr(file_converter, "run_chat_conversion", fake_chat)
+    monkeypatch.setattr(file_converter, "run_doc_conversion", fake_doc)
+
+    file_converter.main([str(doc_file), "-o", str(output_file), "-f", "html", "--force"])
+
+    assert 'doc' in called
+    assert 'chat' not in called


### PR DESCRIPTION
## Summary
- provide a markdown adapter that falls back to the stdlib when markdown2 is unavailable and update the converter libraries to use it with package-friendly imports
- enhance the converter CLIs with reusable parsers, detailed --help-examples/--help-verbose text, and consistent argument handling
- add pytest coverage for chat, document, and universal converters including CLI help output and dispatcher behaviour

## Testing
- pytest tests/test_converters -q

------
https://chatgpt.com/codex/tasks/task_e_68f687ae55848331b3684465b07aa958