### PR TITLE
Improve converter CLIs and add tests

### DIFF
--- a/src/conversions/__init__.py
+++ b/src/conversions/__init__.py
@@ -1,0 +1,10 @@
+"""Conversion tools for chat histories and documents."""
+
+__all__ = [
+    "chat_history_converter",
+    "doc_converter",
+    "file_converter",
+    "conversion_utils",
+    "lib_chat_converter",
+    "lib_doc_converter",
+]

--- a/src/conversions/lib_chat_converter.py
+++ b/src/conversions/lib_chat_converter.py
@@ -1,8 +1,11 @@
 # lib_chat_converter.py
 import re
-import markdown2
 from datetime import datetime
-import conversion_utils as utils
+
+try:  # pragma: no cover - import error path exercised via fallback
+    from . import conversion_utils as utils
+except ImportError:  # pragma: no cover - fallback for script execution
+    import conversion_utils as utils  # type: ignore
 
 """
 Parses a Markdown file formatted for chat logs, expecting 'role: content'
@@ -84,7 +87,7 @@ Returns:
 """
 def to_html_chat(metadata, messages, css_content):
     title = metadata.get('title', 'Chat History')
-    markdowner = markdown2.Markdown(extras=["tables", "fenced-code-blocks", "strike"])
+    markdowner = utils.get_markdown_converter(["tables", "fenced-code-blocks", "strike"])
 
     message_html_parts = []
     for msg in messages:

--- a/src/conversions/lib_doc_converter.py
+++ b/src/conversions/lib_doc_converter.py
@@ -1,7 +1,10 @@
 # lib_doc_converter.py
-import markdown2
-import conversion_utils as utils
 import yaml
+
+try:  # pragma: no cover - import error path exercised via fallback
+    from . import conversion_utils as utils
+except ImportError:  # pragma: no cover - fallback for script execution
+    import conversion_utils as utils  # type: ignore
 
 """
 * Recursively converts a Python object (from YAML/JSON) into an HTML string
@@ -93,7 +96,7 @@ def to_html_document(metadata, content, css_content, include_toc=True):
 
         if isinstance(doc, str): # Handle Markdown content
             # (Logic for markdown remains the same)
-            markdowner = markdown2.Markdown(extras=["toc", "tables", "fenced-code-blocks", "strike"])
+            markdowner = utils.get_markdown_converter(["toc", "tables", "fenced-code-blocks", "strike"])
             html_part = markdowner.convert(doc)
             final_html_content += f'<div class="content">{html_part}</div>'
         elif isinstance(doc, dict): # Handle structured data

--- a/tests/test_converters/conftest.py
+++ b/tests/test_converters/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_converters/test_chat_history_converter.py
+++ b/tests/test_converters/test_chat_history_converter.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+import pytest
+
+from conversions import chat_history_converter, conversion_utils
+
+
+def test_get_markdown_converter_fallback(monkeypatch):
+    """Ensure the fallback converter operates when markdown2 is unavailable."""
+    monkeypatch.setattr(conversion_utils, "_markdown2", None, raising=False)
+    converter = conversion_utils.get_markdown_converter()
+    result = converter.convert("Hello\n\nWorld")
+    assert "<p>" in result and "World" in result
+
+
+def test_chat_history_conversion_html_output(tmp_path):
+    chat_file = tmp_path / "chat.md"
+    chat_file.write_text("user: Hello\nassistant: Hi there!", encoding="utf-8")
+
+    output_file = tmp_path / "chat.html"
+    args = SimpleNamespace(
+        input_file=str(chat_file),
+        output=str(output_file),
+        format="html",
+        analyze=False,
+    )
+
+    chat_history_converter.run_chat_conversion(args)
+
+    html = output_file.read_text(encoding="utf-8")
+    assert "Chat History" in html
+    assert "Hello" in html and "Hi there" in html
+
+
+def test_chat_help_examples(capsys):
+    parser = chat_history_converter.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--help-examples"])
+    out = capsys.readouterr()
+    combined = f"{out.out}\n{out.err}"
+    assert "Examples:" in combined
+    assert "logs.json" in combined
+    assert "chat_history_converter.py" in combined

--- a/tests/test_converters/test_doc_converter.py
+++ b/tests/test_converters/test_doc_converter.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+
+import pytest
+
+from conversions import doc_converter
+
+
+def test_doc_conversion_markdown_to_html(tmp_path):
+    doc_file = tmp_path / "doc.md"
+    doc_file.write_text("# Title\n\nSome content.", encoding="utf-8")
+
+    output_file = tmp_path / "doc.html"
+    args = SimpleNamespace(
+        input_file=str(doc_file),
+        output=str(output_file),
+        format="html",
+        no_toc=False,
+    )
+
+    doc_converter.run_doc_conversion(args)
+    html = output_file.read_text(encoding="utf-8")
+    assert "Title" in html
+    assert "Some content" in html
+
+
+def test_doc_help_verbose(capsys):
+    parser = doc_converter.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--help-verbose"])
+    out = capsys.readouterr()
+    combined = f"{out.out}\n{out.err}"
+    assert "Additional Details" in combined
+    assert "YAML streams" in combined

--- a/tests/test_converters/test_file_converter.py
+++ b/tests/test_converters/test_file_converter.py
@@ -1,0 +1,41 @@
+import sys
+
+import pytest
+
+from conversions import file_converter
+
+
+def test_file_converter_routes_chat(tmp_path, monkeypatch, capsys):
+    chat_file = tmp_path / "chat.md"
+    chat_file.write_text("user: Hello\nassistant: Hi!", encoding="utf-8")
+    output_file = tmp_path / "chat.html"
+
+    args = [
+        "file_converter.py",
+        str(chat_file),
+        "--format",
+        "html",
+        "--output",
+        str(output_file),
+        "--force",
+    ]
+
+    monkeypatch.setattr(sys, "argv", args)
+    file_converter.main()
+
+    captured = capsys.readouterr()
+    combined = f"{captured.out}\n{captured.err}"
+    assert "Chat file detected" in combined
+    assert output_file.exists()
+    html = output_file.read_text(encoding="utf-8")
+    assert "Hello" in html and "Hi" in html
+
+
+def test_file_converter_help_examples(capsys):
+    parser = file_converter.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--help-examples"])
+    out = capsys.readouterr()
+    combined = f"{out.out}\n{out.err}"
+    assert "Examples:" in combined
+    assert "file_converter.py" in combined


### PR DESCRIPTION
## Summary
- update the converter CLIs to support extended help modes and safe relative imports
- add a markdown conversion fallback and shared help utilities to avoid optional dependency failures
- create pytest coverage for the chat, document, and unified file converters

## Testing
- pytest tests/test_converters -q

------
https://chatgpt.com/codex/tasks/task_e_68f687ae55848331b3684465b07aa958