### PR TITLE
Improve converter CLI robustness and help

### DIFF
--- a/src/conversions/chat_history_converter.py
+++ b/src/conversions/chat_history_converter.py
@@ -10,8 +10,38 @@ This script is intended to be called by a master dispatcher.
 import argparse
 import os
 import sys
+from typing import Any, Dict, Iterable, Tuple
+
 import lib_chat_converter as converter
 import conversion_utils as utils
+from textwrap import dedent
+
+
+class ConversionError(Exception):
+    """Custom exception used to signal conversion failures."""
+
+    def __init__(self, message: str, *, hint: str | None = None) -> None:
+        super().__init__(message)
+        self.hint = hint
+
+
+def _normalize_format(value: str | None, *, default: str = "html") -> str:
+    """Return a normalized output format value."""
+
+    if not value:
+        return default
+
+    normalized = value.lower().lstrip(".")
+    if normalized == "yaml":
+        normalized = "yml"
+    return normalized
+
+
+def _safe_splitext(path: str) -> Tuple[str, str]:
+    """os.path.splitext but always lower-cases the extension."""
+
+    base, ext = os.path.splitext(path)
+    return base, ext.lower().replace(".", "")
 
 # Default CSS for HTML Output
 DEFAULT_CSS = """
@@ -31,77 +61,85 @@ h1 { text-align: center; color: #1a1a1a; font-size: 2em; margin-bottom: 20px; pa
 """
 
 
-"""
-Runs the full conversion and analysis pipeline for a chat history file.
-
-Args:
-    args (argparse.Namespace): The parsed command-line arguments.
-
-Returns:
-    None. Prints status to stdout/stderr and writes files.
-"""
-
-
 def run_chat_conversion(args):
-    # --- Parsing Logic ---
-    metadata, messages = {}, []
-    input_ext = os.path.splitext(args.input_file)[1].lower().replace(".", "")
+    """Execute the chat conversion and return a user-facing status message."""
+
+    input_path = os.path.expanduser(args.input_file)
+    if not os.path.exists(input_path):
+        raise ConversionError(
+            f"Input file not found: {args.input_file}",
+            hint="Verify the path or use an absolute location.",
+        )
+
+    _, input_ext = _safe_splitext(input_path)
     if input_ext == "yaml":
         input_ext = "yml"
 
-    if input_ext == "md":
-        metadata, messages = converter.parse_markdown_chat(args.input_file)
-    elif input_ext in ["json", "yml"]:
-        content = utils.read_file_content(args.input_file)
-        data = (
-            utils.load_json_from_string(content)
-            if input_ext == "json"
-            else utils.load_yaml_from_string(content)
-        )
-        if "error" in data:
-            metadata = {"error": data["error"]}
-        else:
+    try:
+        metadata: Dict[str, Any]
+        messages: Iterable[Dict[str, Any]]
+        if input_ext == "md":
+            metadata, messages = converter.parse_markdown_chat(input_path)
+        elif input_ext in {"json", "yml"}:
+            content = utils.read_file_content(input_path)
+            if isinstance(content, dict) and "error" in content:
+                raise ConversionError(content["error"])
+
+            loader = utils.load_json_from_string if input_ext == "json" else utils.load_yaml_from_string
+            data = loader(content)  # type: ignore[arg-type]
+            if isinstance(data, dict) and "error" in data:
+                raise ConversionError(data["error"], hint="Double-check the source formatting.")
+
+            if not isinstance(data, dict):
+                raise ConversionError(
+                    "The chat file did not contain the expected mapping structure.",
+                    hint="Ensure the file has top-level 'metadata' and 'messages' keys.",
+                )
+
             metadata = data.get("metadata", {})
             messages = data.get("messages", [])
-    else:
-        print(f"Error: Invalid chat file format '{input_ext}'.", file=sys.stderr)
-        sys.exit(1)
+        else:
+            raise ConversionError(
+                f"Unsupported chat file format: {input_ext or 'unknown'}",
+                hint="Use .md, .json, or .yml chat export files.",
+            )
+    except ConversionError:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ConversionError(f"Unexpected failure while parsing chat file: {exc}") from exc
 
-    if "error" in metadata:
-        print(f"Error parsing chat file: {metadata['error']}", file=sys.stderr)
-        sys.exit(1)
+    if isinstance(metadata, dict) and "error" in metadata:
+        raise ConversionError(metadata["error"])
 
-    # --- Feature: Analyze ---
+    messages_list = list(messages)
+
     if args.analyze:
-        analysis = converter.analyze_chat(messages)
-        print("Chat Analysis:")
+        analysis = converter.analyze_chat(messages_list)
+        lines = ["Chat Analysis:"]
         for key, value in analysis.items():
-            print(f"- {key.replace('_', ' ').title()}: {value}")
-        return
+            lines.append(f"- {key.replace('_', ' ').title()}: {value}")
+        return "\n".join(lines)
 
-    # --- Writer Selection ---
-    output_content = ""
-    if args.format == "html":
-        output_content = converter.to_html_chat(metadata, messages, DEFAULT_CSS)
-    elif args.format == "md":
-        output_content = converter.to_markdown_chat(metadata, messages)
-    elif args.format == "json":
-        output_content = utils.to_json_string(
-            {"metadata": metadata, "messages": messages}
-        )
-    elif args.format == "yml":
-        output_content = utils.to_yaml_string(
-            {"metadata": metadata, "messages": messages}
-        )
+    output_format = _normalize_format(args.format)
+    if output_format == "html":
+        output_content = converter.to_html_chat(metadata, messages_list, DEFAULT_CSS)
+    elif output_format == "md":
+        output_content = converter.to_markdown_chat(metadata, messages_list)
+    elif output_format == "json":
+        output_content = utils.to_json_string({"metadata": metadata, "messages": messages_list})
+    elif output_format == "yml":
+        output_content = utils.to_yaml_string({"metadata": metadata, "messages": messages_list})
     else:
-        print(f"Error: Unsupported output format '{args.format}'.", file=sys.stderr)
-        sys.exit(1)
+        raise ConversionError(
+            f"Unsupported output format: {output_format}",
+            hint="Choose from html, md, json, or yml.",
+        )
 
     result = utils.write_file_content(args.output, output_content)
     if "error" in result:
-        print(f"Error: {result['error']}", file=sys.stderr)
-    else:
-        print(f"Successfully converted chat to '{args.output}'")
+        raise ConversionError(result["error"])
+
+    return f"Successfully converted chat to '{args.output}'"
 
 
 """
@@ -109,25 +147,86 @@ Main entry point for running this script directly.
 """
 
 
+def build_parser() -> argparse.ArgumentParser:
+    """Create a parser with extensive usage documentation."""
+
+    description = dedent(
+        """
+        Convert exported chat histories between Markdown, JSON, YAML, and HTML.
+
+        The converter automatically preserves metadata (when available) and can
+        optionally perform a quick statistical analysis of the dialogue.
+        """
+    ).strip()
+
+    epilog = dedent(
+        """
+        Examples:
+          - Convert a Markdown transcript to HTML:
+                chat_history_converter.py chat.md --format html
+          - Inspect a JSON chat export without writing output:
+                chat_history_converter.py export.json --analyze
+          - Convert YAML to Markdown and specify the destination file:
+                chat_history_converter.py conversation.yml -o story.md
+        """
+    )
+
+    parser = argparse.ArgumentParser(
+        description=description,
+        epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("input_file", help="Path to the chat history file (md, json, yml).")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output file path. Defaults to <input-name>.<format>.",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        dest="format",
+        help="Desired output format: html, md, json, or yml.",
+    )
+    parser.add_argument(
+        "--analyze",
+        action="store_true",
+        help="Print chat statistics instead of writing an output file.",
+    )
+    return parser
+
+
 def main():
-    parser = argparse.ArgumentParser(description="Standalone Chat History Converter.")
-    parser.add_argument("input_file")
-    parser.add_argument("-o", "--output")
-    parser.add_argument("-f", "--format")
-    parser.add_argument("--analyze", action="store_true")
+    parser = build_parser()
     args = parser.parse_args()
 
-    # Simple defaulting for standalone mode
-    if not args.format and args.output:
-        args.format = os.path.splitext(args.output)[1].lower().replace(".", "")
-    elif not args.format:
-        args.format = "html"
+    output_format = _normalize_format(getattr(args, "format", None))
 
-    if not args.output:
-        base_name = os.path.splitext(args.input_file)[0]
-        args.output = f"{base_name}.{args.format}"
+    if args.output:
+        base_out, out_ext = _safe_splitext(args.output)
+        if not args.format and out_ext:
+            output_format = out_ext or output_format
+        elif args.format and out_ext and out_ext != output_format:
+            print(
+                f"Warning: Output extension '.{out_ext}' differs from requested format '{output_format}'.",
+                file=sys.stderr,
+            )
+            args.output = f"{base_out}.{output_format}"
+    else:
+        base_name, _ = _safe_splitext(args.input_file)
+        args.output = f"{base_name}.{output_format}"
 
-    run_chat_conversion(args)
+    args.format = output_format
+
+    try:
+        message = run_chat_conversion(args)
+        if message:
+            print(message)
+    except ConversionError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        if getattr(exc, "hint", None):
+            print(f"Hint: {exc.hint}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/conversions/doc_converter.py
+++ b/src/conversions/doc_converter.py
@@ -9,8 +9,32 @@ This script is intended to be called by a master dispatcher.
 import argparse
 import os
 import sys
+from typing import Tuple
+
 import lib_doc_converter as converter
 import conversion_utils as utils
+from textwrap import dedent
+
+
+class ConversionError(Exception):
+    """Custom exception raised when document conversion fails."""
+
+    def __init__(self, message: str, *, hint: str | None = None) -> None:
+        super().__init__(message)
+        self.hint = hint
+
+
+def _normalize_format(value: str | None, *, default: str = "html") -> str:
+    if not value:
+        return default
+
+    normalized = value.lower().lstrip(".")
+    return "yml" if normalized == "yaml" else normalized
+
+
+def _safe_splitext(path: str) -> Tuple[str, str]:
+    base, ext = os.path.splitext(path)
+    return base, ext.lower().replace(".", "")
 
 # Default CSS for HTML Output
 DEFAULT_CSS = """
@@ -24,58 +48,62 @@ h1 { text-align: center; color: #1a1a1a; font-size: 2em; margin-bottom: 20px; pa
 .toc ul { padding-left: 20px; }
 """
 
-"""
-Runs the full conversion pipeline for a single document file.
-
-Args:
-    args (argparse.Namespace): The parsed command-line arguments.
-
-Returns:
-    None. Prints status to stdout/stderr and writes files.
-"""
-
-
 def run_doc_conversion(args):
-    input_ext = os.path.splitext(args.input_file)[1].lower().replace(".", "")
+    """Execute the document conversion workflow and return a status message."""
+
+    input_path = os.path.expanduser(args.input_file)
+    if not os.path.exists(input_path):
+        raise ConversionError(
+            f"Input file not found: {args.input_file}",
+            hint="Provide a valid path to a document file.",
+        )
+
+    _, input_ext = _safe_splitext(input_path)
     if input_ext == "yaml":
         input_ext = "yml"
 
-    # --- Parsing Logic ---
-    metadata, content = converter.parse_document(args.input_file, input_ext)
-    if "error" in metadata:
-        print(f"Error parsing document: {metadata['error']}", file=sys.stderr)
-        sys.exit(1)
+    try:
+        metadata, content = converter.parse_document(input_path, input_ext)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ConversionError(f"Failed to parse document: {exc}") from exc
+
+    if isinstance(metadata, dict) and "error" in metadata:
+        raise ConversionError(metadata["error"])
+
+    if not isinstance(metadata, dict):
+        raise ConversionError(
+            "The document metadata is not a mapping.",
+            hint="Ensure the parser returned a metadata dictionary.",
+        )
 
     if "title" not in metadata:
-        metadata["title"] = os.path.splitext(os.path.basename(args.input_file))[
-            0
-        ].replace("_", " ")
+        metadata["title"] = os.path.splitext(os.path.basename(input_path))[0].replace(
+            "_",
+            " ",
+        )
 
-    # --- Writer Selection ---
-    output_content = ""
-    if args.format == "html":
+    output_format = _normalize_format(args.format)
+    if output_format == "html":
         output_content = converter.to_html_document(
             metadata, content, DEFAULT_CSS, include_toc=not args.no_toc
         )
-    elif args.format == "md":
+    elif output_format == "md":
         output_content = content
-    elif args.format == "json":
-        output_content = utils.to_json_string(
-            {"metadata": metadata, "content": content}
-        )
-    elif args.format == "yml":
-        output_content = utils.to_yaml_string(
-            {"metadata": metadata, "content": content}
-        )
+    elif output_format == "json":
+        output_content = utils.to_json_string({"metadata": metadata, "content": content})
+    elif output_format == "yml":
+        output_content = utils.to_yaml_string({"metadata": metadata, "content": content})
     else:
-        print(f"Error: Unsupported output format '{args.format}'.", file=sys.stderr)
-        sys.exit(1)
+        raise ConversionError(
+            f"Unsupported output format: {output_format}",
+            hint="Choose from html, md, json, or yml.",
+        )
 
     result = utils.write_file_content(args.output, output_content)
     if "error" in result:
-        print(f"Error: {result['error']}", file=sys.stderr)
-    else:
-        print(f"Successfully converted document to '{args.output}'")
+        raise ConversionError(result["error"])
+
+    return f"Successfully converted document to '{args.output}'"
 
 
 """
@@ -83,25 +111,84 @@ Main entry point for running this script directly.
 """
 
 
+def build_parser() -> argparse.ArgumentParser:
+    description = dedent(
+        """
+        Convert structured documents to HTML, Markdown, JSON, or YAML.
+
+        The converter preserves metadata and can optionally suppress the
+        auto-generated Table of Contents in HTML output.
+        """
+    ).strip()
+
+    epilog = dedent(
+        """
+        Examples:
+          - Generate an HTML report with a Table of Contents:
+                doc_converter.py report.md --format html
+          - Create a JSON representation of a Markdown handbook:
+                doc_converter.py handbook.md -f json -o handbook.json
+          - Render HTML without a Table of Contents:
+                doc_converter.py guide.md --no-toc
+        """
+    )
+
+    parser = argparse.ArgumentParser(
+        description=description,
+        epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("input_file", help="Path to the source document (md, json, yml).")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output file path. Defaults to <input-name>.<format>.",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        dest="format",
+        help="Desired output format: html, md, json, or yml.",
+    )
+    parser.add_argument(
+        "--no-toc",
+        action="store_true",
+        help="Skip the Table of Contents when producing HTML output.",
+    )
+    return parser
+
+
 def main():
-    parser = argparse.ArgumentParser(description="Standalone Document Converter.")
-    parser.add_argument("input_file")
-    parser.add_argument("-o", "--output")
-    parser.add_argument("-f", "--format")
-    parser.add_argument("--no-toc", action="store_true")
+    parser = build_parser()
     args = parser.parse_args()
 
-    # Simple defaulting for standalone mode
-    if not args.format and args.output:
-        args.format = os.path.splitext(args.output)[1].lower().replace(".", "")
-    elif not args.format:
-        args.format = "html"
+    output_format = _normalize_format(getattr(args, "format", None))
 
-    if not args.output:
-        base_name = os.path.splitext(args.input_file)[0]
-        args.output = f"{base_name}.{args.format}"
+    if args.output:
+        base_out, out_ext = _safe_splitext(args.output)
+        if not args.format and out_ext:
+            output_format = out_ext or output_format
+        elif args.format and out_ext and out_ext != output_format:
+            print(
+                f"Warning: Output extension '.{out_ext}' differs from requested format '{output_format}'.",
+                file=sys.stderr,
+            )
+            args.output = f"{base_out}.{output_format}"
+    else:
+        base_name, _ = _safe_splitext(args.input_file)
+        args.output = f"{base_name}.{output_format}"
 
-    run_doc_conversion(args)
+    args.format = output_format
+
+    try:
+        message = run_doc_conversion(args)
+        if message:
+            print(message)
+    except ConversionError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        if getattr(exc, "hint", None):
+            print(f"Hint: {exc.hint}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/conversions/file_converter.py
+++ b/src/conversions/file_converter.py
@@ -11,10 +11,15 @@ import argparse
 import os
 import sys
 import re
+from textwrap import dedent
+from typing import Tuple
 
 # Import the callable functions from the specialized scripts
-from chat_history_converter import run_chat_conversion
-from doc_converter import run_doc_conversion
+from chat_history_converter import (
+    ConversionError as ChatConversionError,
+    run_chat_conversion,
+)
+from doc_converter import ConversionError as DocConversionError, run_doc_conversion
 
 
 """
@@ -42,25 +47,69 @@ def is_chat_file(file_path):
         return False
 
 
-"""
-The main dispatcher function.
-"""
+def _normalize_format(value: str | None, *, default: str = "html") -> str:
+    if not value:
+        return default
+
+    normalized = value.lower().lstrip(".")
+    return "yml" if normalized == "yaml" else normalized
 
 
-def main():
+def _safe_splitext(path: str) -> Tuple[str, str]:
+    base, ext = os.path.splitext(path)
+    return base, ext.lower().replace(".", "")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    description = dedent(
+        """
+        Detects whether the input file is a chat history or a document and
+        dispatches to the appropriate specialized converter.
+
+        The tool supports graceful error handling, format normalization, and
+        optional safeguards against overwriting files.
+        """
+    ).strip()
+
+    epilog = dedent(
+        """
+        Examples:
+          - Automatically detect the type and convert to HTML:
+                file_converter.py transcript.md -f html
+          - Force document mode and emit JSON:
+                file_converter.py paper.md --input-type doc --format json
+          - Analyze a chat export without writing a file:
+                file_converter.py support.json --input-type chat --analyze
+        """
+    )
+
     parser = argparse.ArgumentParser(
-        description="A unified tool to convert chat histories and documents.",
-        formatter_class=argparse.RawTextHelpFormatter,
-        add_help=False,
+        description=description,
+        epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+
     # --- Universal Arguments ---
-    parser.add_argument("input_file", help="Path to the input file.")
-    parser.add_argument("-o", "--output", help="Path for the output file.")
+    parser.add_argument("input_file", help="Path to the input file to convert.")
     parser.add_argument(
-        "-f", "--format", choices=["json", "yml", "md", "html"], help="Output format."
+        "-o", "--output", help="Path for the output file. Defaults to <input>.<format>."
     )
     parser.add_argument(
-        "--force", action="store_true", help="Force overwrite of output file."
+        "-f",
+        "--format",
+        choices=["json", "yml", "md", "html"],
+        help="Output format to produce.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force overwrite of the output file if it already exists.",
+    )
+    parser.add_argument(
+        "--input-type",
+        choices=["auto", "chat", "doc"],
+        default="auto",
+        help="Override automatic detection and explicitly choose a converter.",
     )
 
     # --- Chat-Specific Arguments ---
@@ -76,49 +125,88 @@ def main():
     doc_group.add_argument(
         "--no-toc",
         action="store_true",
-        help="Disable Table of Contents in HTML output.",
+        help="Disable the Table of Contents in HTML output.",
     )
 
-    # --- Help ---
-    parser.add_argument(
-        "-h",
-        "--help",
-        "-?",
-        "--Help",
-        action="help",
-        help="Show this help message and exit.",
-    )
+    return parser
 
+
+def _determine_input_type(input_path: str, mode: str) -> Tuple[str, str]:
+    if mode in {"chat", "doc"}:
+        return mode, f"Input type forced to '{mode}'."
+
+    detected = "chat" if is_chat_file(input_path) else "doc"
+    reason = (
+        "Detected chat-specific markers; routing to chat converter."
+        if detected == "chat"
+        else "No chat markers detected; routing to document converter."
+    )
+    return detected, reason
+
+
+"""
+The main dispatcher function.
+"""
+
+
+def main():
+    parser = build_parser()
     args = parser.parse_args()
 
-    if not os.path.exists(args.input_file):
+    input_path = os.path.expanduser(args.input_file)
+    if not os.path.exists(input_path):
         print(f"Error: Input file not found at '{args.input_file}'", file=sys.stderr)
         sys.exit(1)
 
-    # --- Set sensible defaults if not provided ---
-    if not args.format and args.output:
-        args.format = os.path.splitext(args.output)[1].lower().replace(".", "")
-    elif not args.format:
-        args.format = "html"  # Default to HTML if no other info
+    target, message = _determine_input_type(input_path, args.input_type)
+    print(message)
 
-    if not args.output:
-        base_name = os.path.splitext(args.input_file)[0]
-        args.output = f"{base_name}.{args.format}"
+    output_format = _normalize_format(args.format)
+    requires_output = not (target == "chat" and args.analyze)
 
-    if os.path.exists(args.output) and not args.force:
-        print(
-            f"Error: Output file '{args.output}' already exists. Use --force to overwrite.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+    if requires_output:
+        if args.output:
+            base_out, out_ext = _safe_splitext(args.output)
+            if not args.format and out_ext:
+                output_format = out_ext or output_format
+            elif args.format and out_ext and out_ext != output_format:
+                print(
+                    f"Warning: Output extension '.{out_ext}' differs from requested format '{output_format}'.",
+                    file=sys.stderr,
+                )
+                args.output = f"{base_out}.{output_format}"
+        else:
+            base_name, _ = _safe_splitext(input_path)
+            args.output = f"{base_name}.{output_format}"
 
-    # --- The Dispatcher Logic ---
-    if is_chat_file(args.input_file):
-        print("Chat file detected. Using chat history converter...")
-        run_chat_conversion(args)
+        if os.path.exists(args.output) and not args.force:
+            print(
+                f"Error: Output file '{args.output}' already exists. Use --force to overwrite.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
     else:
-        print("Document file detected. Using document converter...")
-        run_doc_conversion(args)
+        args.output = args.output or ""
+
+    args.format = output_format
+
+    try:
+        if target == "chat":
+            result_message = run_chat_conversion(args)
+        else:
+            result_message = run_doc_conversion(args)
+
+        if result_message:
+            print(result_message)
+    except (ChatConversionError, DocConversionError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        hint = getattr(exc, "hint", None)
+        if hint:
+            print(f"Hint: {hint}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"Unexpected error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add conversion-specific exceptions and richer error handling to the chat and document converters while normalising output formats
- expand the CLI parsers with detailed descriptions, examples, and smarter default handling for chat and document tools
- enhance the unified file converter with detection overrides, improved help text, and safer output management including analyze-only workflows

## Testing
- python -m compileall src/conversions

------
https://chatgpt.com/codex/tasks/task_e_68f7292ac5f08331a03f90107d1a3133