### PR TITLE
Improve converter CLI resilience and UX

### DIFF
--- a/src/conversions/chat_history_converter.py
+++ b/src/conversions/chat_history_converter.py
@@ -10,8 +10,17 @@ This script is intended to be called by a master dispatcher.
 import argparse
 import os
 import sys
+from typing import Any, Dict, Iterable, Tuple
+
 import lib_chat_converter as converter
 import conversion_utils as utils
+
+
+class ConversionError(RuntimeError):
+    """Raised when a chat history conversion cannot be completed."""
+
+
+SUPPORTED_FORMATS: Tuple[str, ...] = ("html", "md", "json", "yml")
 
 # Default CSS for HTML Output
 DEFAULT_CSS = """
@@ -42,66 +51,92 @@ Returns:
 """
 
 
-def run_chat_conversion(args):
-    # --- Parsing Logic ---
-    metadata, messages = {}, []
-    input_ext = os.path.splitext(args.input_file)[1].lower().replace(".", "")
+def _normalize_extension(path: str) -> str:
+    """Return the lowercase file extension without a leading dot."""
+
+    return os.path.splitext(path)[1].lower().replace(".", "")
+
+
+def _validate_format(requested_format: str) -> str:
+    if requested_format not in SUPPORTED_FORMATS:
+        raise ConversionError(
+            "Unsupported output format '" + requested_format + "'. "
+            "Choose from: " + ", ".join(SUPPORTED_FORMATS)
+        )
+    return requested_format
+
+
+def run_chat_conversion(args) -> Dict[str, Any]:
+    """Execute a chat conversion for the provided CLI arguments.
+
+    Returns:
+        dict: Information about the conversion, including the output path.
+
+    Raises:
+        ConversionError: If any part of the conversion fails.
+    """
+
+    input_ext = _normalize_extension(args.input_file)
     if input_ext == "yaml":
         input_ext = "yml"
 
-    if input_ext == "md":
-        metadata, messages = converter.parse_markdown_chat(args.input_file)
-    elif input_ext in ["json", "yml"]:
-        content = utils.read_file_content(args.input_file)
-        data = (
-            utils.load_json_from_string(content)
-            if input_ext == "json"
-            else utils.load_yaml_from_string(content)
-        )
-        if "error" in data:
-            metadata = {"error": data["error"]}
+    metadata: Dict[str, Any] = {}
+    messages: Iterable[Dict[str, Any]] = []
+
+    try:
+        if input_ext == "md":
+            metadata, messages = converter.parse_markdown_chat(args.input_file)
+        elif input_ext in ("json", "yml"):
+            content = utils.read_file_content(args.input_file)
+            if isinstance(content, dict) and "error" in content:
+                raise ConversionError(content["error"])
+
+            data = (
+                utils.load_json_from_string(content)
+                if input_ext == "json"
+                else utils.load_yaml_from_string(content)
+            )
+            if isinstance(data, dict) and "error" in data:
+                raise ConversionError(data["error"])
+
+            metadata = data.get("metadata", {}) if isinstance(data, dict) else {}
+            messages = data.get("messages", []) if isinstance(data, dict) else []
         else:
-            metadata = data.get("metadata", {})
-            messages = data.get("messages", [])
-    else:
-        print(f"Error: Invalid chat file format '{input_ext}'.", file=sys.stderr)
-        sys.exit(1)
+            raise ConversionError(
+                f"Invalid chat file format '{input_ext}'. Supported: md, json, yml"
+            )
+    except OSError as exc:
+        raise ConversionError(
+            f"Failed to read chat file '{args.input_file}': {exc}"
+        ) from exc
 
-    if "error" in metadata:
-        print(f"Error parsing chat file: {metadata['error']}", file=sys.stderr)
-        sys.exit(1)
+    if isinstance(metadata, dict) and "error" in metadata:
+        raise ConversionError(f"Error parsing chat file: {metadata['error']}")
 
-    # --- Feature: Analyze ---
+    requested_format = _validate_format(args.format)
+
     if args.analyze:
         analysis = converter.analyze_chat(messages)
-        print("Chat Analysis:")
-        for key, value in analysis.items():
-            print(f"- {key.replace('_', ' ').title()}: {value}")
-        return
+        return {"analysis": analysis, "output": None, "format": requested_format}
 
-    # --- Writer Selection ---
-    output_content = ""
-    if args.format == "html":
+    if requested_format == "html":
         output_content = converter.to_html_chat(metadata, messages, DEFAULT_CSS)
-    elif args.format == "md":
+    elif requested_format == "md":
         output_content = converter.to_markdown_chat(metadata, messages)
-    elif args.format == "json":
+    elif requested_format == "json":
         output_content = utils.to_json_string(
-            {"metadata": metadata, "messages": messages}
+            {"metadata": metadata, "messages": list(messages)}
         )
-    elif args.format == "yml":
+    else:  # requested_format == "yml"
         output_content = utils.to_yaml_string(
-            {"metadata": metadata, "messages": messages}
+            {"metadata": metadata, "messages": list(messages)}
         )
-    else:
-        print(f"Error: Unsupported output format '{args.format}'.", file=sys.stderr)
-        sys.exit(1)
 
     result = utils.write_file_content(args.output, output_content)
     if "error" in result:
-        print(f"Error: {result['error']}", file=sys.stderr)
-    else:
-        print(f"Successfully converted chat to '{args.output}'")
+        raise ConversionError(result["error"])
+
+    return {"output": args.output, "format": requested_format}
 
 
 """
@@ -109,25 +144,70 @@ Main entry point for running this script directly.
 """
 
 
+def _infer_format(args) -> str:
+    if args.format:
+        return args.format.lower()
+    if args.output:
+        inferred = _normalize_extension(args.output)
+        if inferred:
+            return inferred
+    return "html"
+
+
+def _resolve_output_path(args, format_: str) -> str:
+    if args.output:
+        return args.output
+    base_name = os.path.splitext(args.input_file)[0]
+    return f"{base_name}.{format_}"
+
+
 def main():
-    parser = argparse.ArgumentParser(description="Standalone Chat History Converter.")
-    parser.add_argument("input_file")
-    parser.add_argument("-o", "--output")
-    parser.add_argument("-f", "--format")
-    parser.add_argument("--analyze", action="store_true")
+    parser = argparse.ArgumentParser(
+        description="Convert structured chat transcripts between Markdown, JSON, YAML, and HTML.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  chat_history_converter.py chat.json --format html\n"
+            "  chat_history_converter.py notes.md -o notes.json\n"
+            "  chat_history_converter.py transcript.yml --analyze\n"
+        ),
+    )
+    parser.add_argument("input_file", help="Path to the chat transcript to convert.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Destination path. Defaults to <input>.<format>.",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=SUPPORTED_FORMATS,
+        help="Output format. Inferred from --output when omitted.",
+    )
+    parser.add_argument(
+        "--analyze",
+        action="store_true",
+        help="Show chat statistics instead of writing a file.",
+    )
     args = parser.parse_args()
 
-    # Simple defaulting for standalone mode
-    if not args.format and args.output:
-        args.format = os.path.splitext(args.output)[1].lower().replace(".", "")
-    elif not args.format:
-        args.format = "html"
+    requested_format = _infer_format(args)
+    args.format = _validate_format(requested_format)
+    args.output = _resolve_output_path(args, args.format)
 
-    if not args.output:
-        base_name = os.path.splitext(args.input_file)[0]
-        args.output = f"{base_name}.{args.format}"
+    try:
+        result = run_chat_conversion(args)
+    except ConversionError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
-    run_chat_conversion(args)
+    if args.analyze:
+        print("Chat Analysis:")
+        for key, value in result["analysis"].items():
+            label = key.replace("_", " ").title()
+            print(f"- {label}: {value}")
+    else:
+        print(f"Successfully converted chat to '{result['output']}'")
 
 
 if __name__ == "__main__":

--- a/src/conversions/doc_converter.py
+++ b/src/conversions/doc_converter.py
@@ -9,8 +9,17 @@ This script is intended to be called by a master dispatcher.
 import argparse
 import os
 import sys
+from typing import Any, Dict, Tuple
+
 import lib_doc_converter as converter
 import conversion_utils as utils
+
+
+class ConversionError(RuntimeError):
+    """Raised when a document conversion cannot be completed."""
+
+
+SUPPORTED_FORMATS: Tuple[str, ...] = ("html", "md", "json", "yml")
 
 # Default CSS for HTML Output
 DEFAULT_CSS = """
@@ -35,47 +44,64 @@ Returns:
 """
 
 
-def run_doc_conversion(args):
-    input_ext = os.path.splitext(args.input_file)[1].lower().replace(".", "")
+def _normalize_extension(path: str) -> str:
+    return os.path.splitext(path)[1].lower().replace(".", "")
+
+
+def _validate_format(requested_format: str) -> str:
+    if requested_format not in SUPPORTED_FORMATS:
+        raise ConversionError(
+            "Unsupported output format '" + requested_format + "'. "
+            "Choose from: " + ", ".join(SUPPORTED_FORMATS)
+        )
+    return requested_format
+
+
+def run_doc_conversion(args) -> Dict[str, Any]:
+    """Execute a document conversion based on parsed CLI arguments."""
+
+    input_ext = _normalize_extension(args.input_file)
     if input_ext == "yaml":
         input_ext = "yml"
 
-    # --- Parsing Logic ---
-    metadata, content = converter.parse_document(args.input_file, input_ext)
+    try:
+        metadata, content = converter.parse_document(args.input_file, input_ext)
+    except OSError as exc:
+        raise ConversionError(
+            f"Failed to read document '{args.input_file}': {exc}"
+        ) from exc
+
     if "error" in metadata:
-        print(f"Error parsing document: {metadata['error']}", file=sys.stderr)
-        sys.exit(1)
+        raise ConversionError(f"Error parsing document: {metadata['error']}")
 
     if "title" not in metadata:
-        metadata["title"] = os.path.splitext(os.path.basename(args.input_file))[
-            0
-        ].replace("_", " ")
+        metadata["title"] = os.path.splitext(os.path.basename(args.input_file))[0].replace(
+            "_",
+            " ",
+        )
 
-    # --- Writer Selection ---
-    output_content = ""
-    if args.format == "html":
+    requested_format = _validate_format(args.format)
+
+    if requested_format == "html":
         output_content = converter.to_html_document(
             metadata, content, DEFAULT_CSS, include_toc=not args.no_toc
         )
-    elif args.format == "md":
+    elif requested_format == "md":
         output_content = content
-    elif args.format == "json":
+    elif requested_format == "json":
         output_content = utils.to_json_string(
             {"metadata": metadata, "content": content}
         )
-    elif args.format == "yml":
+    else:  # requested_format == "yml"
         output_content = utils.to_yaml_string(
             {"metadata": metadata, "content": content}
         )
-    else:
-        print(f"Error: Unsupported output format '{args.format}'.", file=sys.stderr)
-        sys.exit(1)
 
     result = utils.write_file_content(args.output, output_content)
     if "error" in result:
-        print(f"Error: {result['error']}", file=sys.stderr)
-    else:
-        print(f"Successfully converted document to '{args.output}'")
+        raise ConversionError(result["error"])
+
+    return {"output": args.output, "format": requested_format}
 
 
 """
@@ -83,25 +109,64 @@ Main entry point for running this script directly.
 """
 
 
+def _infer_format(args) -> str:
+    if args.format:
+        return args.format.lower()
+    if args.output:
+        inferred = _normalize_extension(args.output)
+        if inferred:
+            return inferred
+    return "html"
+
+
+def _resolve_output_path(args, format_: str) -> str:
+    if args.output:
+        return args.output
+    base_name = os.path.splitext(args.input_file)[0]
+    return f"{base_name}.{format_}"
+
+
 def main():
-    parser = argparse.ArgumentParser(description="Standalone Document Converter.")
-    parser.add_argument("input_file")
-    parser.add_argument("-o", "--output")
-    parser.add_argument("-f", "--format")
-    parser.add_argument("--no-toc", action="store_true")
+    parser = argparse.ArgumentParser(
+        description="Convert documents between Markdown, JSON, YAML, and HTML.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  doc_converter.py README.md --format html\n"
+            "  doc_converter.py handbook.json -o handbook.md\n"
+            "  doc_converter.py manual.yml --no-toc\n"
+        ),
+    )
+    parser.add_argument("input_file", help="Path to the document to convert.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Destination path. Defaults to <input>.<format>.",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=SUPPORTED_FORMATS,
+        help="Output format. Inferred from --output when omitted.",
+    )
+    parser.add_argument(
+        "--no-toc",
+        action="store_true",
+        help="Omit the generated table of contents when producing HTML.",
+    )
     args = parser.parse_args()
 
-    # Simple defaulting for standalone mode
-    if not args.format and args.output:
-        args.format = os.path.splitext(args.output)[1].lower().replace(".", "")
-    elif not args.format:
-        args.format = "html"
+    requested_format = _infer_format(args)
+    args.format = _validate_format(requested_format)
+    args.output = _resolve_output_path(args, args.format)
 
-    if not args.output:
-        base_name = os.path.splitext(args.input_file)[0]
-        args.output = f"{base_name}.{args.format}"
+    try:
+        result = run_doc_conversion(args)
+    except ConversionError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
-    run_doc_conversion(args)
+    print(f"Successfully converted document to '{result['output']}'")
 
 
 if __name__ == "__main__":

--- a/src/conversions/file_converter.py
+++ b/src/conversions/file_converter.py
@@ -9,12 +9,22 @@ It automatically detects the file type and calls the appropriate conversion logi
 
 import argparse
 import os
-import sys
 import re
+import sys
+from typing import Optional
 
 # Import the callable functions from the specialized scripts
-from chat_history_converter import run_chat_conversion
-from doc_converter import run_doc_conversion
+from chat_history_converter import (
+    ConversionError as ChatConversionError,
+    SUPPORTED_FORMATS as CHAT_FORMATS,
+    run_chat_conversion,
+)
+from doc_converter import (
+    ConversionError as DocConversionError,
+    run_doc_conversion,
+)
+
+SUPPORTED_FORMATS = CHAT_FORMATS
 
 
 """
@@ -31,15 +41,40 @@ Returns:
 def is_chat_file(file_path):
     try:
         with open(file_path, "r", encoding="utf-8") as f:
-            # Read a sample of the file to check for chat patterns
-            sample = f.read(2048)
-            # The heuristic: look for 'user:', 'assistant:', etc. at line starts
+            sample = f.read(4096)
             chat_pattern = re.compile(
                 r"^\s*(user|assistant|system)\s*:", re.IGNORECASE | re.MULTILINE
             )
             return bool(chat_pattern.search(sample))
-    except Exception:
+    except (OSError, UnicodeDecodeError):
         return False
+
+
+def _normalize_extension(path: str) -> str:
+    return os.path.splitext(path)[1].lower().replace(".", "")
+
+
+def _infer_format(format_arg: Optional[str], output: Optional[str]) -> str:
+    if format_arg:
+        return format_arg.lower()
+    if output:
+        inferred = _normalize_extension(output)
+        if inferred:
+            return inferred
+    return "html"
+
+
+def _resolve_output_path(output: Optional[str], input_file: str, format_: str) -> str:
+    if output:
+        return output
+    base_name = os.path.splitext(input_file)[0]
+    return f"{base_name}.{format_}"
+
+
+def _determine_input_mode(input_type: Optional[str], input_file: str) -> str:
+    if input_type:
+        return input_type
+    return "chat" if is_chat_file(input_file) else "document"
 
 
 """
@@ -49,37 +84,54 @@ The main dispatcher function.
 
 def main():
     parser = argparse.ArgumentParser(
-        description="A unified tool to convert chat histories and documents.",
-        formatter_class=argparse.RawTextHelpFormatter,
+        description="Convert chat transcripts or documents to HTML, Markdown, JSON, or YAML.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         add_help=False,
-    )
-    # --- Universal Arguments ---
-    parser.add_argument("input_file", help="Path to the input file.")
-    parser.add_argument("-o", "--output", help="Path for the output file.")
-    parser.add_argument(
-        "-f", "--format", choices=["json", "yml", "md", "html"], help="Output format."
-    )
-    parser.add_argument(
-        "--force", action="store_true", help="Force overwrite of output file."
+        epilog=(
+            "Examples:\n"
+            "  file_converter.py transcript.json --format html\n"
+            "  file_converter.py meeting.md -o meeting.json --analyze\n"
+            "  file_converter.py handbook.md --input-type document --no-toc\n"
+        ),
     )
 
-    # --- Chat-Specific Arguments ---
-    chat_group = parser.add_argument_group("Chat-Specific Options")
+    parser.add_argument("input_file", help="Path to the input chat transcript or document.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Destination path. Defaults to <input>.<format>.",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=SUPPORTED_FORMATS,
+        help="Output format. Inferred from --output when omitted.",
+    )
+    parser.add_argument(
+        "--input-type",
+        choices=["chat", "document"],
+        help="Skip auto-detection and force either chat or document conversion.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite the output file if it already exists.",
+    )
+
+    chat_group = parser.add_argument_group("Chat Options")
     chat_group.add_argument(
         "--analyze",
         action="store_true",
-        help="Display chat statistics instead of converting.",
+        help="Display chat statistics instead of writing a file.",
     )
 
-    # --- Document-Specific Arguments ---
-    doc_group = parser.add_argument_group("Document-Specific Options")
+    doc_group = parser.add_argument_group("Document Options")
     doc_group.add_argument(
         "--no-toc",
         action="store_true",
-        help="Disable Table of Contents in HTML output.",
+        help="Disable the table of contents in HTML output.",
     )
 
-    # --- Help ---
     parser.add_argument(
         "-h",
         "--help",
@@ -95,15 +147,17 @@ def main():
         print(f"Error: Input file not found at '{args.input_file}'", file=sys.stderr)
         sys.exit(1)
 
-    # --- Set sensible defaults if not provided ---
-    if not args.format and args.output:
-        args.format = os.path.splitext(args.output)[1].lower().replace(".", "")
-    elif not args.format:
-        args.format = "html"  # Default to HTML if no other info
+    requested_format = _infer_format(args.format, args.output)
+    if requested_format not in SUPPORTED_FORMATS:
+        print(
+            "Error: Unsupported format '" + requested_format + "'. "
+            "Choose from: " + ", ".join(SUPPORTED_FORMATS),
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
-    if not args.output:
-        base_name = os.path.splitext(args.input_file)[0]
-        args.output = f"{base_name}.{args.format}"
+    args.format = requested_format
+    args.output = _resolve_output_path(args.output, args.input_file, args.format)
 
     if os.path.exists(args.output) and not args.force:
         print(
@@ -112,13 +166,26 @@ def main():
         )
         sys.exit(1)
 
-    # --- The Dispatcher Logic ---
-    if is_chat_file(args.input_file):
-        print("Chat file detected. Using chat history converter...")
-        run_chat_conversion(args)
+    mode = _determine_input_mode(args.input_type, args.input_file)
+
+    try:
+        if mode == "chat":
+            print("Chat file selected. Running chat history converter...")
+            result = run_chat_conversion(args)
+        else:
+            print("Document file selected. Running document converter...")
+            result = run_doc_conversion(args)
+    except (ChatConversionError, DocConversionError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if getattr(args, "analyze", False):
+        print("Chat Analysis:")
+        for key, value in result["analysis"].items():
+            label = key.replace("_", " ").title()
+            print(f"- {label}: {value}")
     else:
-        print("Document file detected. Using document converter...")
-        run_doc_conversion(args)
+        print(f"Successfully wrote '{result['output']}'")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add explicit conversion error handling and format validation to the chat and document converters
- expand the individual converter CLIs with richer help text and smarter default inference
- harden the unified file converter with input type overrides, clearer messaging, and shared format handling

## Testing
- python -m compileall src/conversions/chat_history_converter.py src/conversions/doc_converter.py src/conversions/file_converter.py

------
https://chatgpt.com/codex/tasks/task_e_68f7292ac5f08331a03f90107d1a3133