### PR TITLE
Add gdir keyword directory jumper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gdir"
+version = "0.1.0"
+description = "Keyword-driven directory jumper"
+readme = "README.md"
+authors = [{name = "gdir"}]
+requires-python = ">=3.9"
+dependencies = []
+
+[project.scripts]
+gdir = "gdir.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/scripts/gdir_install.sh
+++ b/scripts/gdir_install.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WRAPPER_BEGIN="# --- gdir wrapper (BEGIN MANAGED BLOCK) ---"
+WRAPPER_END="# --- gdir wrapper (END MANAGED BLOCK) ---"
+
+install_bash() {
+  local rc_file="$HOME/.bashrc"
+  local block
+  read -r -d '' block <<'EOF'
+# --- gdir wrapper (BEGIN MANAGED BLOCK) ---
+gdir() {
+  case "$1" in
+    go|back|fwd)
+      local target
+      target="$(command gdir "$@")" || return $?
+      [ -z "$target" ] && return 2
+      cd "$target" || return $?
+      eval "$(command gdir env --format sh)"
+      ;;
+    *)
+      command gdir "$@"
+      ;;
+  esac
+}
+trap 'command gdir save >/dev/null 2>&1' EXIT
+# --- gdir wrapper (END MANAGED BLOCK) ---
+EOF
+  ensure_block "$rc_file" "$block"
+  install_bash_completion
+  printf 'Installed gdir wrapper in %s\n' "$rc_file"
+}
+
+install_zsh() {
+  local rc_file="$HOME/.zshrc"
+  local block
+  read -r -d '' block <<'EOF'
+# --- gdir wrapper (BEGIN MANAGED BLOCK) ---
+function gdir() {
+  case "$1" in
+    go|back|fwd)
+      local target
+      target="$(command gdir "$@")" || return $?
+      [[ -z "$target" ]] && return 2
+      cd "$target" || return $?
+      eval "$(command gdir env --format sh)"
+      ;;
+    *)
+      command gdir "$@"
+      ;;
+  esac
+}
+trap 'command gdir save >/dev/null 2>&1' EXIT
+# --- gdir wrapper (END MANAGED BLOCK) ---
+EOF
+  ensure_block "$rc_file" "$block"
+  install_zsh_completion
+  printf 'Installed gdir wrapper in %s\n' "$rc_file"
+}
+
+install_fish() {
+  local func_dir="$HOME/.config/fish/functions"
+  local comp_dir="$HOME/.config/fish/completions"
+  mkdir -p "$func_dir" "$comp_dir"
+  cat >"$func_dir/gdir.fish" <<'EOF'
+function gdir
+  switch $argv[1]
+    case go back fwd
+      set target (command gdir $argv)
+      or return $status
+      test -z "$target"; and return 2
+      cd $target; or return $status
+      command gdir env --format fish | source
+    case '*'
+      command gdir $argv
+  end
+end
+function __gdir_autosave --on-event fish_exit
+  command gdir save >/dev/null 2>&1
+end
+EOF
+  cat >"$comp_dir/gdir.fish" <<'EOF'
+function __gdir_keywords
+  command gdir list 2>/dev/null | awk 'NR>2 { print $2 }'
+end
+complete -c gdir -n '__fish_seen_subcommand_from go rm' -a '(__gdir_keywords)'
+EOF
+  printf 'Installed gdir function in %s\n' "$func_dir/gdir.fish"
+}
+
+ensure_block() {
+  local file="$1"
+  local block="$2"
+  mkdir -p "$(dirname "$file")"
+  local tmp
+  tmp=$(mktemp)
+  if [[ -f "$file" ]]; then
+    awk -v begin="$WRAPPER_BEGIN" -v end="$WRAPPER_END" '
+      $0 == begin {in_block=1; next}
+      $0 == end {in_block=0; next}
+      !in_block {print}
+    ' "$file" >"$tmp"
+  fi
+  printf '\n%s\n' "$block" >>"$tmp"
+  mv "$tmp" "$file"
+}
+
+install_bash_completion() {
+  local completion_dir="$HOME/.local/share/bash-completion/completions"
+  mkdir -p "$completion_dir"
+  cat >"$completion_dir/gdir" <<'EOF'
+_gdir_complete() {
+  local cur prev
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  mapfile -t keys < <(command gdir list 2>/dev/null | awk 'NR>2 { print $2 }')
+  COMPREPLY=( $(compgen -W "${keys[*]}" -- "$cur") )
+}
+complete -F _gdir_complete gdir
+EOF
+}
+
+install_zsh_completion() {
+  local completion_dir="$HOME/.zsh/completions"
+  mkdir -p "$completion_dir"
+  cat >"$completion_dir/_gdir" <<'EOF'
+#compdef gdir
+_arguments '*:keyword:->keywords'
+_keywords() {
+  command gdir list 2>/dev/null | awk 'NR>2 { print $2 }'
+}
+case $state in
+  keywords)
+    _values 'gdir keywords' $(_keywords)
+  ;;
+esac
+EOF
+  if ! grep -Fq 'fpath+=~/.zsh/completions' "$HOME/.zshrc" 2>/dev/null; then
+    printf '\nfpath+=~/.zsh/completions\n' >>"$HOME/.zshrc"
+  fi
+}
+
+usage() {
+  cat <<'EOF'
+Usage: gdir_install.sh [--shell bash|zsh|fish]
+EOF
+}
+
+shell_name=${1:-}
+case "$shell_name" in
+  --shell)
+    shift
+    shell_name=${1:-}
+    shift || true
+    ;;
+  "")
+    shell_name=$(basename "${SHELL:-bash}")
+    ;;
+esac
+
+case "$shell_name" in
+  bash)
+    install_bash
+    ;;
+  zsh)
+    install_zsh
+    ;;
+  fish)
+    install_fish
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac
+
+command gdir save >/dev/null 2>&1 || true
+printf 'gdir installation complete. Restart your shell to use gdir.\n'

--- a/src/gdir/__init__.py
+++ b/src/gdir/__init__.py
@@ -1,0 +1,7 @@
+"""gdir package."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/gdir/cli.py
+++ b/src/gdir/cli.py
@@ -1,0 +1,459 @@
+"""Command line interface for gdir."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import subprocess
+from pathlib import Path
+from shutil import which
+from typing import Iterable, List, Optional
+
+from . import __version__
+from .helptext import HELP_TEXT
+from .store import (
+    History,
+    HistoryEntry,
+    MappingEntry,
+    MappingStore,
+    StoreError,
+    ensure_config_dir,
+    resolve_path,
+)
+
+EXIT_USAGE = 64
+EXIT_INVALID = 2
+EXIT_INTERNAL = 70
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="gdir", add_help=False)
+    parser.add_argument("--config", type=Path, default=None, help="Override config directory")
+    parser.add_argument("--version", action="store_true", help="Show version")
+    subparsers = parser.add_subparsers(dest="command")
+
+    subparsers.add_parser("list")
+
+    add_parser = subparsers.add_parser("add")
+    add_parser.add_argument("key")
+    add_parser.add_argument("directory")
+    add_parser.add_argument("--force", action="store_true", help="Allow missing directories")
+
+    rm_parser = subparsers.add_parser("rm")
+    rm_parser.add_argument("selector")
+
+    clear_parser = subparsers.add_parser("clear")
+    clear_parser.add_argument("--yes", action="store_true")
+
+    go_parser = subparsers.add_parser("go")
+    go_parser.add_argument("selector")
+
+    back_parser = subparsers.add_parser("back")
+    back_parser.add_argument("steps", nargs="?", type=int, default=1)
+
+    fwd_parser = subparsers.add_parser("fwd")
+    fwd_parser.add_argument("steps", nargs="?", type=int, default=1)
+
+    hist_parser = subparsers.add_parser("hist")
+    hist_parser.add_argument("--before", type=int, default=5)
+    hist_parser.add_argument("--after", type=int, default=5)
+
+    env_parser = subparsers.add_parser("env")
+    env_parser.add_argument("--format", choices=["sh", "fish", "pwsh"], default="sh")
+    env_parser.add_argument("--per-key", action="store_true")
+
+    save_parser = subparsers.add_parser("save")
+    save_parser.add_argument("file", nargs="?")
+
+    load_parser = subparsers.add_parser("load")
+    load_parser.add_argument("file", nargs="?")
+
+    import_parser = subparsers.add_parser("import")
+    import_parser.add_argument("source", choices=["cdargs", "bashmarks"])
+
+    subparsers.add_parser("pick")
+    subparsers.add_parser("doctor")
+    subparsers.add_parser("help")
+
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    if args.version and not args.command:
+        print(__version__)
+        return 0
+    if not args.command:
+        parser.print_help()
+        return 0
+
+    config_dir = ensure_config_dir(args.config)
+    store = MappingStore.load(config_dir)
+    history = History.load(config_dir)
+
+    try:
+        if args.command == "list":
+            return cmd_list(store)
+        if args.command == "add":
+            return cmd_add(store, args.key, args.directory, args.force)
+        if args.command == "rm":
+            return cmd_rm(store, args.selector)
+        if args.command == "clear":
+            return cmd_clear(store, args.yes)
+        if args.command == "go":
+            return cmd_go(store, history, args.selector)
+        if args.command == "back":
+            return cmd_back(history, args.steps)
+        if args.command == "fwd":
+            return cmd_forward(history, args.steps)
+        if args.command == "hist":
+            return cmd_hist(history, args.before, args.after)
+        if args.command == "env":
+            return cmd_env(store, history, args.format, args.per_key)
+        if args.command == "save":
+            return cmd_save(store, history, args.file)
+        if args.command == "load":
+            return cmd_load(store, history, args.file)
+        if args.command == "import":
+            return cmd_import(store, args.source)
+        if args.command == "pick":
+            return cmd_pick(store, history)
+        if args.command == "doctor":
+            return cmd_doctor(config_dir, store, history)
+        if args.command == "help":
+            print(HELP_TEXT)
+            return 0
+        parser.print_help()
+        return EXIT_USAGE
+    except StoreError as exc:
+        print(str(exc), file=sys.stderr)
+        return EXIT_INVALID
+    except KeyboardInterrupt:
+        return 130
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"Internal error: {exc}", file=sys.stderr)
+        return EXIT_INTERNAL
+
+
+def cmd_list(store: MappingStore) -> int:
+    entries = store.list()
+    if not entries:
+        print("No mappings defined.")
+        return 0
+    index_width = len(str(len(entries)))
+    key_width = max(len("keyword"), *(len(entry.key) for entry in entries))
+    header = f"{'index'.rjust(index_width)}  {'keyword'.ljust(key_width)}  directory"
+    print(header)
+    print("-" * len(header))
+    for idx, entry in enumerate(entries, start=1):
+        print(
+            f"{str(idx).rjust(index_width)}  {entry.key.ljust(key_width)}  {entry.path}"
+        )
+    return 0
+
+
+def cmd_add(
+    store: MappingStore,
+    key: str,
+    directory: str,
+    force: bool,
+) -> int:
+    entry = store.add(key, directory, allow_missing=force)
+    store.save()
+    print(f"Saved {entry.key} -> {entry.path}")
+    return 0
+
+
+def cmd_rm(store: MappingStore, selector: str) -> int:
+    entry = store.remove(selector)
+    store.save()
+    print(f"Removed {entry.key}")
+    return 0
+
+
+def cmd_clear(store: MappingStore, confirmed: bool) -> int:
+    if not confirmed:
+        print("Use --yes to confirm clearing all mappings.", file=sys.stderr)
+        return EXIT_USAGE
+    store.clear()
+    store.save()
+    print("All mappings cleared.")
+    return 0
+
+
+def cmd_go(store: MappingStore, history: History, selector: str) -> int:
+    entry = store.get(selector)
+    if entry is None:
+        print("Mapping not found.", file=sys.stderr)
+        return EXIT_INVALID
+    path = Path(entry.path)
+    if not path.exists():
+        print("Target directory does not exist.", file=sys.stderr)
+        return EXIT_INVALID
+    history.visit(path)
+    history.save()
+    print(str(resolve_path(path)))
+    return 0
+
+
+def cmd_back(history: History, steps: int) -> int:
+    if steps <= 0:
+        print("Steps must be positive.", file=sys.stderr)
+        return EXIT_USAGE
+    entry = history.back(steps)
+    if entry is None:
+        print("No previous history entry.", file=sys.stderr)
+        return EXIT_INVALID
+    history.save()
+    print(entry.path)
+    return 0
+
+
+def cmd_forward(history: History, steps: int) -> int:
+    if steps <= 0:
+        print("Steps must be positive.", file=sys.stderr)
+        return EXIT_USAGE
+    entry = history.forward(steps)
+    if entry is None:
+        print("No forward history entry.", file=sys.stderr)
+        return EXIT_INVALID
+    history.save()
+    print(entry.path)
+    return 0
+
+
+def cmd_hist(history: History, before: int, after: int) -> int:
+    if before < 0 or after < 0:
+        print("before/after must be non-negative.", file=sys.stderr)
+        return EXIT_USAGE
+    rows = history.window(before, after)
+    if not rows:
+        print("History is empty.")
+        return 0
+    index_width = len(str(len(history.entries)))
+    header = f"{'index'.rjust(index_width)}  visited_at                directory"
+    print(header)
+    print("-" * len(header))
+    for idx, entry, is_current in rows:
+        marker = "➤" if is_current else " "
+        index = str(idx + 1).rjust(index_width)
+        print(f"{marker}{index}  {entry.visited_at:<24} {entry.path}")
+    return 0
+
+
+def cmd_env(
+    store: MappingStore,
+    history: History,
+    fmt: str,
+    per_key: bool,
+) -> int:
+    prev_path, next_path = history.prev_next()
+    lines: List[str] = []
+    if fmt == "sh":
+        if prev_path:
+            lines.append(_shell_assign("GODIR_PREV", prev_path))
+        else:
+            lines.append("unset GODIR_PREV 2>/dev/null || true")
+        if next_path:
+            lines.append(_shell_assign("GODIR_NEXT", next_path))
+        else:
+            lines.append("unset GODIR_NEXT 2>/dev/null || true")
+        if per_key:
+            for entry in store.list():
+                lines.append(_shell_assign(_key_env(entry.key), entry.path))
+    elif fmt == "fish":
+        if prev_path:
+            lines.append(f"set -gx GODIR_PREV '{prev_path}'")
+        else:
+            lines.append("set -e GODIR_PREV")
+        if next_path:
+            lines.append(f"set -gx GODIR_NEXT '{next_path}'")
+        else:
+            lines.append("set -e GODIR_NEXT")
+        if per_key:
+            for entry in store.list():
+                lines.append(f"set -gx {_key_env(entry.key)} '{entry.path}'")
+    else:  # pwsh
+        if prev_path:
+            lines.append(f"$env:GODIR_PREV = '{prev_path}'")
+        else:
+            lines.append("Remove-Item Env:GODIR_PREV -ErrorAction SilentlyContinue")
+        if next_path:
+            lines.append(f"$env:GODIR_NEXT = '{next_path}'")
+        else:
+            lines.append("Remove-Item Env:GODIR_NEXT -ErrorAction SilentlyContinue")
+        if per_key:
+            for entry in store.list():
+                lines.append(f"$env:{_key_env(entry.key)} = '{entry.path}'")
+    print("\n".join(lines))
+    return 0
+
+
+def _shell_assign(name: str, value: str) -> str:
+    return f"export {name}='{value}'"
+
+
+def _key_env(key: str) -> str:
+    sanitized = re.sub(r"[^A-Za-z0-9]", "_", key.upper())
+    return f"GDIR_{sanitized}"
+
+
+def cmd_save(store: MappingStore, history: History, file: Optional[str]) -> int:
+    store.save()
+    history.save()
+    if file:
+        path = Path(file).expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "mappings": [entry.as_dict() for entry in store.list()],
+            "history": {
+                "entries": [entry.as_dict() for entry in history.entries],
+                "pointer": history.pointer,
+            },
+        }
+        path.write_text(json.dumps(payload, indent=2) + "\n", "utf-8")
+    return 0
+
+
+def cmd_load(store: MappingStore, history: History, file: Optional[str]) -> int:
+    if file:
+        path = Path(file).expanduser()
+        if not path.exists():
+            print("Load file not found.", file=sys.stderr)
+            return EXIT_INVALID
+        payload = json.loads(path.read_text("utf-8"))
+        mappings = [
+            MappingEntry(
+                key=item["key"],
+                path=item["path"],
+                added_at=item.get("added_at") or "",
+            )
+            for item in payload.get("mappings", [])
+        ]
+        history_entries = [
+            HistoryEntry(path=item["path"], visited_at=item.get("visited_at") or "")
+            for item in payload.get("history", {}).get("entries", [])
+        ]
+        store.entries = mappings
+        history.entries = history_entries
+        pointer = payload.get("history", {}).get("pointer")
+        if pointer is None:
+            history.pointer = len(history.entries) - 1
+        else:
+            history.pointer = int(pointer)
+    else:
+        # Reload from default persistence
+        config_dir = store.config_dir
+        store.entries = MappingStore.load(config_dir).entries
+        loaded_history = History.load(config_dir)
+        history.entries = loaded_history.entries
+        history.pointer = loaded_history.pointer
+    store.save()
+    history.save()
+    print("State loaded.")
+    return 0
+
+
+def cmd_import(store: MappingStore, source: str) -> int:
+    if source == "cdargs":
+        imported = import_cdargs(store)
+    else:
+        imported = import_bashmarks(store)
+    store.save()
+    if imported:
+        print(f"Imported {imported} mappings from {source}.")
+    else:
+        print(f"No mappings imported from {source}.")
+    return 0
+
+
+def import_cdargs(store: MappingStore) -> int:
+    cdargs_file = Path.home() / ".cdargs"
+    if not cdargs_file.exists():
+        return 0
+    count = 0
+    for line in cdargs_file.read_text("utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        key, directory = parts[0], parts[1]
+        try:
+            store.add(key, directory, allow_missing=False)
+            count += 1
+        except StoreError:
+            continue
+    return count
+
+
+def import_bashmarks(store: MappingStore) -> int:
+    sdirs = Path.home() / ".sdirs"
+    if not sdirs.exists():
+        return 0
+    count = 0
+    for line in sdirs.read_text("utf-8").splitlines():
+        line = line.strip()
+        if not line.startswith("export "):
+            continue
+        _, rest = line.split("export ", 1)
+        if "=" not in rest:
+            continue
+        name, value = rest.split("=", 1)
+        key = name.lower()
+        directory = value.strip().strip('\"').strip("'")
+        try:
+            store.add(key, directory, allow_missing=False)
+            count += 1
+        except StoreError:
+            continue
+    return count
+
+
+def cmd_pick(store: MappingStore, history: History) -> int:
+    if which("fzf") is None:
+        print("fzf not found in PATH.", file=sys.stderr)
+        return EXIT_INVALID
+    entries = store.list()
+    if not entries:
+        print("No mappings defined.", file=sys.stderr)
+        return EXIT_INVALID
+    display = "\n".join(f"{entry.key}\t{entry.path}" for entry in entries)
+    proc = subprocess.Popen(
+        ["fzf", "--with-nth", "1"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    out, err = proc.communicate(display)
+    if proc.returncode != 0:
+        return proc.returncode
+    if not out.strip():
+        return EXIT_INVALID
+    key = out.split("\t", 1)[0].strip()
+    return cmd_go(store, history, key)
+
+
+def cmd_doctor(config_dir: Path, store: MappingStore, history: History) -> int:
+    issues: List[str] = []
+    if not store.mapping_path.exists():
+        issues.append("mappings.json not found; run 'gdir add' to create one.")
+    if not history.history_path.exists():
+        issues.append("history.jsonl not found; will be created after navigation.")
+    if issues:
+        for issue in issues:
+            print(f"- {issue}")
+    else:
+        print(f"Configuration directory: {config_dir}")
+        print(f"Mappings: {len(store.entries)} entries")
+        print(f"History entries: {len(history.entries)}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/gdir/helptext.py
+++ b/src/gdir/helptext.py
@@ -1,0 +1,30 @@
+"""Static help text for gdir."""
+
+from __future__ import annotations
+
+HELP_TEXT = """
+Usage: gdir <command> [options]
+
+Commands
+  list                     Show keyword mappings.
+  add <key> <dir>          Add or update a mapping.
+  rm <key|index>           Remove a mapping by keyword or index.
+  clear [--yes]            Remove all mappings.
+  go <key|index>           Print the directory for the mapping.
+  back [N]                 Move backward in history.
+  fwd [N]                  Move forward in history.
+  hist                     Show a history window around the current pointer.
+  env [--format F]         Emit environment exports.
+  save [file]              Persist state immediately (and optionally to file).
+  load [file]              Load state from disk (or from file).
+  import <source>          Import bookmarks (cdargs or bashmarks).
+  pick                     Choose a mapping via fzf if available.
+  doctor                   Diagnose configuration issues.
+  help                     Display this help information.
+
+Examples
+  gdir add work ~/src/work
+  gdir go work
+  gdir back
+  gdir env --format sh --per-key
+""".strip()

--- a/src/gdir/store.py
+++ b/src/gdir/store.py
@@ -1,0 +1,279 @@
+"""Persistence and history management for gdir."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+KEY_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+class StoreError(RuntimeError):
+    """Raised when an operation on the store fails."""
+
+
+@dataclass
+class MappingEntry:
+    """Represents a keyword to directory mapping."""
+
+    key: str
+    path: str
+    added_at: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"key": self.key, "path": self.path, "added_at": self.added_at}
+
+
+@dataclass
+class HistoryEntry:
+    """Represents a directory visit."""
+
+    path: str
+    visited_at: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"path": self.path, "visited_at": self.visited_at}
+
+
+@dataclass
+class MappingStore:
+    """Container for keyword mappings."""
+
+    config_dir: Path
+    entries: List[MappingEntry] = field(default_factory=list)
+
+    @property
+    def mapping_path(self) -> Path:
+        return self.config_dir / "mappings.json"
+
+    @classmethod
+    def load(cls, config_dir: Path) -> "MappingStore":
+        config_dir = ensure_config_dir(config_dir)
+        mapping_path = config_dir / "mappings.json"
+        entries: List[MappingEntry] = []
+        if mapping_path.exists():
+            data = json.loads(mapping_path.read_text("utf-8"))
+            for item in data:
+                entries.append(
+                    MappingEntry(
+                        key=item["key"],
+                        path=item["path"],
+                        added_at=item.get("added_at") or _now(),
+                    )
+                )
+        return cls(config_dir=config_dir, entries=entries)
+
+    def list(self) -> List[MappingEntry]:
+        return list(self.entries)
+
+    def save(self) -> None:
+        ensure_config_dir(self.config_dir)
+        data = [entry.as_dict() for entry in self.entries]
+        atomic_write_json(self.mapping_path, data)
+
+    def clear(self) -> None:
+        self.entries.clear()
+
+    def add(self, key: str, path: str, *, allow_missing: bool = False) -> MappingEntry:
+        if not KEY_PATTERN.match(key):
+            raise StoreError(
+                "Invalid key. Keys may contain letters, numbers, dot, underscore and hyphen only."
+            )
+        resolved = resolve_path(path)
+        if not allow_missing and not resolved.exists():
+            raise StoreError(f"Directory does not exist: {resolved}")
+        resolved_path = str(resolved)
+        existing = self._find_index_by_key(key)
+        timestamp = _now()
+        if existing is not None:
+            self.entries[existing] = MappingEntry(key=key, path=resolved_path, added_at=timestamp)
+            return self.entries[existing]
+        entry = MappingEntry(key=key, path=resolved_path, added_at=timestamp)
+        self.entries.append(entry)
+        return entry
+
+    def remove(self, selector: str) -> MappingEntry:
+        """Remove an entry by key or 1-based index."""
+
+        index = self._resolve_selector(selector)
+        if index is None:
+            raise StoreError(f"No mapping found for '{selector}'.")
+        entry = self.entries.pop(index)
+        return entry
+
+    def get(self, selector: str) -> Optional[MappingEntry]:
+        index = self._resolve_selector(selector)
+        if index is None:
+            return None
+        return self.entries[index]
+
+    def _resolve_selector(self, selector: str) -> Optional[int]:
+        if selector.isdigit():
+            idx = int(selector) - 1
+            if 0 <= idx < len(self.entries):
+                return idx
+            return None
+        return self._find_index_by_key(selector)
+
+    def _find_index_by_key(self, key: str) -> Optional[int]:
+        for index, entry in enumerate(self.entries):
+            if entry.key == key:
+                return index
+        return None
+
+
+@dataclass
+class History:
+    """Maintains visit history."""
+
+    config_dir: Path
+    entries: List[HistoryEntry] = field(default_factory=list)
+    pointer: int = -1
+
+    @property
+    def history_path(self) -> Path:
+        return self.config_dir / "history.jsonl"
+
+    @property
+    def state_path(self) -> Path:
+        return self.config_dir / "state.json"
+
+    @classmethod
+    def load(cls, config_dir: Path) -> "History":
+        config_dir = ensure_config_dir(config_dir)
+        entries: List[HistoryEntry] = []
+        history_path = config_dir / "history.jsonl"
+        if history_path.exists():
+            for line in history_path.read_text("utf-8").splitlines():
+                if not line.strip():
+                    continue
+                data = json.loads(line)
+                entries.append(
+                    HistoryEntry(
+                        path=data["path"],
+                        visited_at=data.get("visited_at") or _now(),
+                    )
+                )
+        pointer = -1
+        state_path = config_dir / "state.json"
+        if state_path.exists():
+            try:
+                state = json.loads(state_path.read_text("utf-8"))
+                pointer = int(state.get("history_index", -1))
+            except Exception:
+                pointer = len(entries) - 1 if entries else -1
+        pointer = min(pointer, len(entries) - 1)
+        if pointer < -1:
+            pointer = -1
+        return cls(config_dir=config_dir, entries=entries, pointer=pointer)
+
+    def visit(self, path: Path) -> HistoryEntry:
+        resolved = str(resolve_path(path))
+        # Trim forward history if pointer is not at end
+        if self.pointer < len(self.entries) - 1:
+            del self.entries[self.pointer + 1 :]
+        entry = HistoryEntry(path=resolved, visited_at=_now())
+        self.entries.append(entry)
+        self.pointer = len(self.entries) - 1
+        return entry
+
+    def back(self, steps: int = 1) -> Optional[HistoryEntry]:
+        if not self.entries:
+            return None
+        target = self.pointer - steps
+        if target < 0:
+            return None
+        self.pointer = target
+        return self.entries[self.pointer]
+
+    def forward(self, steps: int = 1) -> Optional[HistoryEntry]:
+        if not self.entries:
+            return None
+        target = self.pointer + steps
+        if target >= len(self.entries):
+            return None
+        self.pointer = target
+        return self.entries[self.pointer]
+
+    def current(self) -> Optional[HistoryEntry]:
+        if 0 <= self.pointer < len(self.entries):
+            return self.entries[self.pointer]
+        return None
+
+    def prev_next(self) -> tuple[Optional[str], Optional[str]]:
+        prev_path = None
+        next_path = None
+        if self.pointer > 0:
+            prev_path = self.entries[self.pointer - 1].path
+        if self.pointer >= 0 and self.pointer < len(self.entries) - 1:
+            next_path = self.entries[self.pointer + 1].path
+        return prev_path, next_path
+
+    def window(self, before: int, after: int) -> Sequence[tuple[int, HistoryEntry, bool]]:
+        if not self.entries:
+            return []
+        start = max(0, self.pointer - before if self.pointer >= 0 else 0)
+        end = min(len(self.entries), (self.pointer + after + 1) if self.pointer >= 0 else before + after)
+        rows: list[tuple[int, HistoryEntry, bool]] = []
+        for idx in range(start, end):
+            entry = self.entries[idx]
+            rows.append((idx, entry, idx == self.pointer))
+        return rows
+
+    def clear(self) -> None:
+        self.entries.clear()
+        self.pointer = -1
+
+    def save(self) -> None:
+        ensure_config_dir(self.config_dir)
+        # history jsonl
+        lines = [json.dumps(entry.as_dict()) for entry in self.entries]
+        atomic_write_text(self.history_path, "\n".join(lines) + ("\n" if lines else ""))
+        state = {"history_index": self.pointer}
+        atomic_write_json(self.state_path, state)
+
+
+def ensure_config_dir(config_dir: Path | None = None) -> Path:
+    config_dir = config_dir or default_config_dir()
+    config_dir.mkdir(parents=True, exist_ok=True)
+    return config_dir
+
+
+def default_config_dir() -> Path:
+    xdg_home = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_home:
+        base = Path(xdg_home)
+    else:
+        base = Path.home() / ".config"
+    return base / "gdir"
+
+
+def resolve_path(path: Path | str) -> Path:
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = (Path.cwd() / candidate).resolve()
+    else:
+        candidate = candidate.resolve()
+    return candidate
+
+
+def atomic_write_json(path: Path, data: object) -> None:
+    temp_path = path.with_suffix(path.suffix + ".tmp")
+    temp_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", "utf-8")
+    os.replace(temp_path, path)
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    temp_path = path.with_suffix(path.suffix + ".tmp")
+    temp_path.write_text(text, "utf-8")
+    os.replace(temp_path, path)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime(ISO_FORMAT)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest
+
+from gdir import cli
+
+
+def test_cli_add_go_env(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    config_dir = tmp_path / "cfg"
+    target = tmp_path / "target"
+    target.mkdir()
+
+    code = cli.main(["--config", str(config_dir), "add", "code", str(target)])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "Saved code" in out
+
+    code = cli.main(["--config", str(config_dir), "list"])
+    out = capsys.readouterr().out
+    assert "code" in out
+
+    code = cli.main(["--config", str(config_dir), "go", "code"])
+    output = capsys.readouterr()
+    assert code == 0
+    assert output.out.strip() == str(target.resolve())
+
+    code = cli.main(["--config", str(config_dir), "back"])
+    output = capsys.readouterr()
+    assert code == cli.EXIT_INVALID
+    assert "No previous" in output.err
+
+    code = cli.main(["--config", str(config_dir), "env", "--format", "sh"])
+    output = capsys.readouterr()
+    assert code == 0
+    assert "GODIR_PREV" in output.out
+
+    code = cli.main(["--config", str(config_dir), "save"])
+    assert code == 0
+    capsys.readouterr()
+
+    code = cli.main(["--config", str(config_dir), "doctor"])
+    output = capsys.readouterr()
+    assert code == 0
+    assert "Configuration directory" in output.out

--- a/tests/test_gdir_history.py
+++ b/tests/test_gdir_history.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from gdir.store import History
+
+
+def test_history_navigation(tmp_path: Path) -> None:
+    history = History.load(tmp_path)
+    for idx in range(3):
+        target = tmp_path / f"dir{idx}"
+        target.mkdir()
+        history.visit(target)
+    assert history.current().path.endswith("dir2")
+
+    entry = history.back()
+    assert entry is not None and entry.path.endswith("dir1")
+    entry = history.back()
+    assert entry is not None and entry.path.endswith("dir0")
+    assert history.back() is None
+    entry = history.forward()
+    assert entry is not None and entry.path.endswith("dir1")
+    history.visit(tmp_path / "new")
+    assert history.forward() is None
+    prev, next_ = history.prev_next()
+    assert prev is not None and next_ is None

--- a/tests/test_gdir_store.py
+++ b/tests/test_gdir_store.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest
+
+from gdir.store import History, MappingStore, StoreError
+
+
+def test_mapping_store_add_update(tmp_path: Path) -> None:
+    store = MappingStore.load(tmp_path)
+    target = tmp_path / "project"
+    target.mkdir()
+    entry = store.add("work", target)
+    assert entry.key == "work"
+    assert Path(entry.path) == target.resolve()
+
+    updated = store.add("work", target / "sub", allow_missing=True)
+    assert updated.path.endswith("sub")
+    store.save()
+
+    loaded = MappingStore.load(tmp_path)
+    assert loaded.get("work").path.endswith("sub")
+
+
+def test_mapping_store_remove_and_clear(tmp_path: Path) -> None:
+    store = MappingStore.load(tmp_path)
+    target = tmp_path / "dir"
+    target.mkdir()
+    store.add("alpha", target)
+    store.add("beta", target)
+    removed = store.remove("1")
+    assert removed.key == "alpha"
+    with pytest.raises(StoreError):
+        store.remove("alpha")
+    store.clear()
+    assert store.list() == []
+
+
+def test_mapping_store_validation(tmp_path: Path) -> None:
+    store = MappingStore.load(tmp_path)
+    with pytest.raises(StoreError):
+        store.add("bad key", tmp_path)
+    with pytest.raises(StoreError):
+        store.add("missing", tmp_path / "missing")
+    store.add("missing", tmp_path / "missing", allow_missing=True)
+
+
+def test_history_roundtrip(tmp_path: Path) -> None:
+    history = History.load(tmp_path)
+    target = tmp_path / "here"
+    target.mkdir()
+    history.visit(target)
+    history.save()
+
+    loaded = History.load(tmp_path)
+    assert loaded.current() is not None
+    assert loaded.back(1) is None
+    loaded.visit(target)
+    entry = loaded.back()
+    assert entry is not None
+    assert loaded.forward() is not None


### PR DESCRIPTION
## Summary
- add a Python-based `gdir` CLI with keyword mapping management, history navigation, environment exports, importers, and help text
- implement persistence utilities for mappings and history with atomic writes and configuration helpers
- provide an installer script, packaging metadata, and regression tests covering the store, history, and CLI flows

## Testing
- pytest -q *(fails: existing repository test import mismatch in tests/test_pygit.py)*
- pytest tests/test_gdir_store.py tests/test_gdir_history.py tests/test_cli_smoke.py -q


------
https://chatgpt.com/codex/tasks/task_e_68f81c5875d08331b0b0bb9198a00f10