### PR TITLE
Add gdir CLI for directory navigation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "python-tools"
+version = "0.0.0"
+description = "Internal utilities"
+requires-python = ">=3.9"
+
+[project.scripts]
+gdir = "gdir.cli:main"

--- a/scripts/gdir_install.sh
+++ b/scripts/gdir_install.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: gdir_install.sh [--shell SHELL]
+
+Options:
+  --shell SHELL   Force installation for the given shell (bash|zsh|fish)
+  -h, --help      Show this message
+USAGE
+}
+
+shell_name=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --shell)
+      shift
+      shell_name="${1:-}"
+      if [[ -z "$shell_name" ]]; then
+        echo "--shell requires a value" >&2
+        exit 64
+      fi
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 64
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "$shell_name" ]]; then
+  shell_name="${SHELL##*/}"
+fi
+
+config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/gdir"
+wrapper_block='\n# --- gdir wrapper (BEGIN MANAGED BLOCK) ---\n'"gdir() {\n  case \"\$1\" in\n    go|back|fwd)\n      local target\n      target=\"\$(command gdir \"\$@\")\" || return \$?\n      [ -z \"\$target\" ] && return 2\n      cd \"\$target\" || return \$?\n      eval \"\$(command gdir env --format sh)\"\n      ;;\n    *)\n      command gdir \"\$@\"\n      ;;\n  esac\n}\ntrap 'command gdir save >/dev/null 2>&1' EXIT\n""# --- gdir wrapper (END MANAGED BLOCK) ---\n"
+
+ensure_block() {
+  local file="$1"
+  local block="$2"
+  mkdir -p "$(dirname "$file")"
+  touch "$file"
+  if grep -Fq "--- gdir wrapper (BEGIN MANAGED BLOCK) ---" "$file"; then
+    return
+  fi
+  printf '%b\n' "$block" >> "$file"
+}
+
+install_bash() {
+  ensure_block "$HOME/.bashrc" "$wrapper_block"
+  mkdir -p "$config_dir/completions"
+  cat > "$config_dir/completions/gdir.bash" <<'COMP'
+_gdir_complete() {
+  local curr prev
+  COMPREPLY=()
+  curr="${COMP_WORDS[COMP_CWORD]}"
+  if [[ $COMP_CWORD -eq 1 ]]; then
+    COMPREPLY=( $(compgen -W "list add rm clear go back fwd hist env save load import pick doctor help keywords" -- "$curr") )
+    return 0
+  fi
+  case "${COMP_WORDS[1]}" in
+    go|rm|pick)
+      local keys
+      keys="$(command gdir keywords 2>/dev/null)"
+      COMPREPLY=( $(compgen -W "$keys" -- "$curr") )
+      ;;
+  esac
+}
+complete -F _gdir_complete gdir
+COMP
+  if ! grep -Fq 'gdir.bash' "$HOME/.bashrc"; then
+    printf '\n[[ -f %q ]] && source %q\n' "$config_dir/completions/gdir.bash" "$config_dir/completions/gdir.bash" >> "$HOME/.bashrc"
+  fi
+}
+
+install_zsh() {
+  ensure_block "$HOME/.zshrc" "$wrapper_block"
+  mkdir -p "$config_dir/completions"
+  cat > "$config_dir/completions/_gdir" <<'COMP'
+#compdef gdir
+_arguments '*: :->subcmd'
+case $state in
+  subcmd)
+    local -a commands
+    commands=(list add rm clear go back fwd hist env save load import pick doctor help keywords)
+    _describe 'command' commands
+    ;;
+  *)
+    local -a keywords
+    keywords=($(command gdir keywords 2>/dev/null))
+    _values 'keyword' $keywords
+    ;;
+ esac
+COMP
+  if ! grep -Fq 'fpath+=${HOME}/.config/gdir/completions' "$HOME/.zshrc"; then
+    printf '\nfpath+=(%q)\nautoload -Uz compinit && compinit\n' "$config_dir/completions" >> "$HOME/.zshrc"
+  fi
+}
+
+install_fish() {
+  mkdir -p "$HOME/.config/fish/functions" "$HOME/.config/fish/completions"
+  cat > "$HOME/.config/fish/functions/gdir.fish" <<'FUNC'
+function gdir
+  set cmd $argv[1]
+  switch $cmd
+    case go back fwd
+      set target (command gdir $argv)
+      test $status -ne 0; and return $status
+      cd $target; or return $status
+      command gdir env --format fish | source
+    case '*'
+      command gdir $argv
+  end
+end
+FUNC
+  cat > "$HOME/.config/fish/completions/gdir.fish" <<'COMP'
+complete -c gdir -n 'not __fish_seen_subcommand_from list add rm clear go back fwd hist env save load import pick doctor help keywords' -a 'list add rm clear go back fwd hist env save load import pick doctor help keywords'
+complete -c gdir -n '__fish_seen_subcommand_from go rm pick' -a '(command gdir keywords 2>/dev/null)'
+COMP
+}
+
+case "$shell_name" in
+  bash)
+    install_bash
+    ;;
+  zsh)
+    install_zsh
+    ;;
+  fish)
+    install_fish
+    ;;
+  *)
+    echo "Unsupported shell: $shell_name" >&2
+    exit 64
+    ;;
+esac
+
+echo "gdir installed for $shell_name"

--- a/src/gdir/__init__.py
+++ b/src/gdir/__init__.py
@@ -1,0 +1,16 @@
+"""gdir package initialization."""
+
+from __future__ import annotations
+
+__all__ = [
+    "MappingStore",
+    "History",
+    "GDirError",
+    "InvalidSelectionError",
+    "UsageError",
+    "InternalError",
+]
+
+from .store import History, MappingStore
+from .errors import GDirError, InvalidSelectionError, UsageError, InternalError
+

--- a/src/gdir/__main__.py
+++ b/src/gdir/__main__.py
@@ -1,0 +1,11 @@
+"""Module entry point for python -m gdir."""
+
+from __future__ import annotations
+
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())
+

--- a/src/gdir/cli.py
+++ b/src/gdir/cli.py
@@ -1,0 +1,380 @@
+"""Command line interface for gdir."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+import json
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from .errors import GDirError, InternalError, InvalidSelectionError, UsageError
+from .helptext import HELP_TEXT
+from .store import (
+    History,
+    HistoryEntry,
+    MappingEntry,
+    MappingStore,
+    default_config_dir,
+    resolve_paths,
+)
+
+
+def _config_directory(raw: Optional[str]) -> Path:
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return default_config_dir()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="gdir", add_help=False)
+    parser.add_argument("--config", help="Override configuration directory")
+    subparsers = parser.add_subparsers(dest="command")
+
+    subparsers.add_parser("list")
+
+    add_parser = subparsers.add_parser("add")
+    add_parser.add_argument("keyword")
+    add_parser.add_argument("directory")
+    add_parser.add_argument("--force", action="store_true", help="Allow non-existent directories")
+
+    rm_parser = subparsers.add_parser("rm")
+    rm_parser.add_argument("identifier")
+
+    clear_parser = subparsers.add_parser("clear")
+    clear_parser.add_argument("--yes", action="store_true", help="Skip confirmation prompt")
+
+    go_parser = subparsers.add_parser("go")
+    go_parser.add_argument("identifier")
+
+    back_parser = subparsers.add_parser("back")
+    back_parser.add_argument("steps", nargs="?", default="1")
+
+    fwd_parser = subparsers.add_parser("fwd")
+    fwd_parser.add_argument("steps", nargs="?", default="1")
+
+    hist_parser = subparsers.add_parser("hist")
+    hist_parser.add_argument("--before", type=int, default=5)
+    hist_parser.add_argument("--after", type=int, default=5)
+
+    env_parser = subparsers.add_parser("env")
+    env_parser.add_argument("--format", choices=["sh", "fish", "pwsh"], default="sh")
+    env_parser.add_argument("--per-key", action="store_true", help="Include per-key exports")
+
+    save_parser = subparsers.add_parser("save")
+    save_parser.add_argument("file", nargs="?")
+
+    load_parser = subparsers.add_parser("load")
+    load_parser.add_argument("file", nargs="?")
+
+    import_parser = subparsers.add_parser("import")
+    import_parser.add_argument("source", choices=["cdargs", "bashmarks"])
+    import_parser.add_argument("--file")
+
+    subparsers.add_parser("pick")
+    subparsers.add_parser("doctor")
+    subparsers.add_parser("help")
+    subparsers.add_parser("keywords")
+
+    return parser
+
+
+def _load_store_and_history(config_dir: Path) -> tuple[MappingStore, History]:
+    mappings_path, history_path, state_path = resolve_paths(config_dir)
+    store = MappingStore(mappings_path)
+    history = History(history_path, state_path)
+    return store, history
+
+
+def _format_table(entries: List[MappingEntry]) -> str:
+    if not entries:
+        return "No mappings defined."
+    idx_width = max(5, len(str(len(entries))))
+    key_width = max(7, max(len(entry.key) for entry in entries))
+    lines = [
+        f"{'index'.rjust(idx_width)}  {'keyword'.ljust(key_width)}  directory",
+    ]
+    for idx, entry in enumerate(entries, start=1):
+        lines.append(f"{str(idx).rjust(idx_width)}  {entry.key.ljust(key_width)}  {entry.path}")
+    return "\n".join(lines)
+
+
+def _parse_steps(raw: str) -> int:
+    if not raw.isdigit() or int(raw) < 1:
+        raise UsageError("Steps must be a positive integer.")
+    return int(raw)
+
+
+def _ensure_exists(path: str) -> None:
+    if not Path(path).exists():
+        raise InvalidSelectionError(f"Mapped directory does not exist: {path}")
+
+
+def _history_output(entries: List[tuple[int, HistoryEntry, bool]]) -> str:
+    if not entries:
+        return "History is empty."
+    lines: List[str] = []
+    for idx, entry, is_current in entries:
+        marker = "\u27a4" if is_current else " "
+        lines.append(f"{marker} {idx + 1:>4}  {entry.path}  ({entry.visited_at})")
+    return "\n".join(lines)
+
+
+def _format_env_exports(data: dict[str, str], fmt: str) -> str:
+    lines: List[str] = []
+    if fmt == "sh":
+        for key, value in data.items():
+            quoted = shlex.quote(value)
+            lines.append(f"export {key}={quoted}")
+    elif fmt == "fish":
+        for key, value in data.items():
+            lines.append(f"set -x {key} {shlex.quote(value)}")
+    else:  # pwsh
+        for key, value in data.items():
+            escaped = value.replace("'", "''")
+            lines.append(f"$Env:{key} = '{escaped}'")
+    return "\n".join(lines)
+
+
+def _load_external_file(file_path: Path) -> List[MappingEntry]:
+    data = json.loads(file_path.read_text(encoding="utf-8"))
+    entries: List[MappingEntry] = []
+    for item in data:
+        key = item.get("key")
+        path = item.get("path")
+        added_at = item.get("added_at") or ""
+        if isinstance(key, str) and isinstance(path, str):
+            entries.append(MappingEntry(key=key, path=path, added_at=added_at))
+    return entries
+
+
+def _import_cdargs(store: MappingStore, override: Optional[str]) -> int:
+    path = Path(override).expanduser() if override else Path.home() / ".cdargs"
+    if not path.exists():
+        return 0
+    added = 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        parts = stripped.split(None, 1)
+        if len(parts) != 2:
+            continue
+        key, directory = parts
+        try:
+            store.add(key, directory, force=True)
+        except UsageError:
+            continue
+        else:
+            added += 1
+    return added
+
+
+def _import_bashmarks(store: MappingStore, override: Optional[str]) -> int:
+    path = Path(override).expanduser() if override else Path.home() / ".sdirs"
+    if not path.exists():
+        return 0
+    added = 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("export "):
+            continue
+        stripped = stripped[len("export ") :]
+        if "=" not in stripped:
+            continue
+        key_part, value_part = stripped.split("=", 1)
+        key = key_part.strip()
+        value = value_part.strip().strip('"')
+        if not key.startswith("DIR_"):
+            continue
+        keyword = key[4:].lower()
+        try:
+            store.add(keyword, value, force=True)
+        except UsageError:
+            continue
+        else:
+            added += 1
+    return added
+
+
+def _doctor_report(config_dir: Path, store: MappingStore, history: History) -> str:
+    lines = [f"Config directory: {config_dir} ({'exists' if config_dir.exists() else 'missing'})"]
+    mappings_path, history_path, state_path = resolve_paths(config_dir)
+    lines.append(f"Mappings file: {mappings_path} ({'exists' if mappings_path.exists() else 'missing'})")
+    lines.append(f"History file: {history_path} ({'exists' if history_path.exists() else 'missing'})")
+    lines.append(f"State file: {state_path} ({'exists' if state_path.exists() else 'missing'})")
+    lines.append(f"Mappings count: {len(store.list())}")
+    lines.append(f"History entries: {len(history.entries)}")
+    current = history.current_path()
+    lines.append(f"Current pointer: {history.pointer if history.entries else 'none'}")
+    lines.append(f"Current path: {current if current else 'n/a'}")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command in {None, "help"}:
+        print(HELP_TEXT.strip())
+        return 0 if args.command == "help" else 64
+
+    config_dir = _config_directory(args.config)
+    try:
+        store, history = _load_store_and_history(config_dir)
+    except UsageError as exc:
+        print(exc, file=sys.stderr)
+        return exc.exit_code
+
+    try:
+        if args.command == "list":
+            print(_format_table(store.list()))
+            return 0
+
+        if args.command == "add":
+            store.add(args.keyword, args.directory, force=args.force)
+            return 0
+
+        if args.command == "rm":
+            store.remove(args.identifier)
+            return 0
+
+        if args.command == "clear":
+            if args.yes:
+                store.clear()
+                return 0
+            response = input("Clear all mappings? [y/N]: ").strip().lower()
+            if response in {"y", "yes"}:
+                store.clear()
+            else:
+                print("Aborted.")
+            return 0
+
+        if args.command == "go":
+            entry = store.get(args.identifier)
+            _ensure_exists(entry.path)
+            history.append(entry.path)
+            print(entry.path)
+            return 0
+
+        if args.command == "back":
+            steps = _parse_steps(args.steps)
+            target_index = history.pointer - steps
+            if target_index < 0:
+                raise InvalidSelectionError("Cannot move back any further.")
+            target_path = history.entries[target_index].path
+            _ensure_exists(target_path)
+            history.move_back(steps)
+            print(target_path)
+            return 0
+
+        if args.command == "fwd":
+            steps = _parse_steps(args.steps)
+            target_index = history.pointer + steps
+            if target_index >= len(history.entries):
+                raise InvalidSelectionError("Cannot move forward any further.")
+            target_path = history.entries[target_index].path
+            _ensure_exists(target_path)
+            history.move_forward(steps)
+            print(target_path)
+            return 0
+
+        if args.command == "hist":
+            print(_history_output(history.window(args.before, args.after)))
+            return 0
+
+        if args.command == "env":
+            exports = {
+                "GODIR_PREV": history.prev_path() or "",
+                "GODIR_NEXT": history.next_path() or "",
+            }
+            if args.per_key:
+                exports.update(store.export_per_key())
+            print(_format_env_exports(exports, args.format))
+            return 0
+
+        if args.command == "save":
+            store.save()
+            history.save()
+            if args.file:
+                destination = Path(args.file).expanduser()
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_text(
+                    json.dumps([asdict(entry) for entry in store.list()], indent=2),
+                    encoding="utf-8",
+                )
+            return 0
+
+        if args.command == "load":
+            if args.file:
+                source = Path(args.file).expanduser()
+            else:
+                mappings_path, _, _ = resolve_paths(config_dir)
+                source = mappings_path
+            if not source.exists():
+                raise InvalidSelectionError(f"Load source not found: {source}")
+            entries = _load_external_file(source)
+            store.set_entries(entries)
+            return 0
+
+        if args.command == "import":
+            if args.source == "cdargs":
+                added = _import_cdargs(store, args.file)
+            else:
+                added = _import_bashmarks(store, args.file)
+            print(f"Imported {added} mappings.")
+            return 0
+
+        if args.command == "pick":
+            if shutil.which("fzf") is None:
+                raise UsageError("fzf not found in PATH.")
+            entries = store.list()
+            if not entries:
+                raise InvalidSelectionError("No mappings available to pick.")
+            payload = "\n".join(f"{entry.key}\t{entry.path}" for entry in entries)
+            proc = subprocess.run(
+                ["fzf", "--with-nth=1"],
+                input=payload,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            if proc.returncode != 0 or not proc.stdout.strip():
+                raise InvalidSelectionError("Selection cancelled.")
+            selected_key = proc.stdout.strip().split("\t", 1)[0]
+            entry = store.get(selected_key)
+            _ensure_exists(entry.path)
+            history.append(entry.path)
+            print(entry.path)
+            return 0
+
+        if args.command == "doctor":
+            print(_doctor_report(config_dir, store, history))
+            return 0
+
+        if args.command == "keywords":
+            for key in store.keywords():
+                print(key)
+            return 0
+
+        raise InternalError("Unknown command")
+
+    except GDirError as exc:
+        if args.command in {"go", "back", "fwd", "pick"} and isinstance(exc, InvalidSelectionError):
+            # For navigation commands we keep stderr quiet unless debugging
+            pass
+        else:
+            print(exc, file=sys.stderr)
+        return exc.exit_code
+    except Exception as exc:  # pragma: no cover - safety net
+        print(f"Unexpected error: {exc}", file=sys.stderr)
+        return 70
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())
+

--- a/src/gdir/errors.py
+++ b/src/gdir/errors.py
@@ -1,0 +1,38 @@
+"""Error hierarchy for gdir."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class GDirError(Exception):
+    """Base exception that carries an exit code."""
+
+    message: str
+    exit_code: int
+
+    def __str__(self) -> str:  # pragma: no cover - simple string repr
+        return self.message
+
+
+class UsageError(GDirError):
+    """Raised when a command is used incorrectly."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message=message, exit_code=64)
+
+
+class InvalidSelectionError(GDirError):
+    """Raised when the requested mapping or history selection is invalid."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message=message, exit_code=2)
+
+
+class InternalError(GDirError):
+    """Raised for unexpected internal failures."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message=message, exit_code=70)
+

--- a/src/gdir/helptext.py
+++ b/src/gdir/helptext.py
@@ -1,0 +1,32 @@
+"""Centralised help text for gdir."""
+
+from __future__ import annotations
+
+HELP_TEXT = """
+Usage: gdir <command> [options]
+
+Commands:
+  list                        Show keyword mappings
+  add <keyword> <dir>         Add or update a mapping
+  rm <index|keyword>          Remove a mapping by index or keyword
+  clear [--yes]               Remove all mappings
+  go <index|keyword>          Print directory and add to history
+  back [N]                    Move back in history (default: 1)
+  fwd [N]                     Move forward in history (default: 1)
+  hist [--before N --after N] Show history around the current pointer
+  env [--format FMT]          Print environment exports (sh|fish|pwsh)
+  save [FILE]                 Save mappings to FILE (default config)
+  load [FILE]                 Load mappings from FILE (default config)
+  import <cdargs|bashmarks>   Import mappings from other tools
+  pick                        Pick mapping via fzf (if installed)
+  doctor                      Diagnose common issues
+  help                        Show this message
+  keywords                    Print mapping keywords (one per line)
+
+Examples:
+  gdir add proj ~/code/project
+  cd "$(gdir go proj)"
+  gdir back
+  eval "$(gdir env --format sh)"
+"""
+

--- a/src/gdir/store.py
+++ b/src/gdir/store.py
@@ -1,0 +1,315 @@
+"""Persistence layer for gdir mappings and history."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+
+from .errors import InvalidSelectionError, UsageError
+
+_KEY_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+CONFIG_ENV_VAR = "GDIR_CONFIG_DIR"
+DEFAULT_DIRNAME = "gdir"
+
+
+@dataclass
+class MappingEntry:
+    """Represents a keyword-directory mapping."""
+
+    key: str
+    path: str
+    added_at: str
+
+
+@dataclass
+class HistoryEntry:
+    """Represents a single visit in the navigation history."""
+
+    path: str
+    visited_at: str
+
+
+class MappingStore:
+    """Manage keyword-to-directory mappings."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._entries: List[MappingEntry] = []
+        self.load()
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _ensure_valid_key(key: str) -> None:
+        if not _KEY_PATTERN.fullmatch(key):
+            raise UsageError(
+                "Keywords must contain only letters, numbers, dots, underscores, or hyphens."
+            )
+
+    @staticmethod
+    def _canonicalize_path(raw_path: str) -> Path:
+        candidate = Path(raw_path).expanduser()
+        if not candidate.is_absolute():
+            candidate = Path.cwd() / candidate
+        try:
+            resolved = candidate.resolve(strict=False)
+        except RuntimeError:  # pragma: no cover - safeguard for rare resolution loops
+            resolved = candidate
+        return resolved
+
+    @property
+    def entries(self) -> List[MappingEntry]:
+        return list(self._entries)
+
+    def load(self) -> None:
+        if not self._path.exists():
+            self._entries = []
+            return
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise UsageError(f"Failed to parse mappings file: {exc}") from exc
+        entries: List[MappingEntry] = []
+        for item in data:
+            key = item.get("key")
+            path = item.get("path")
+            added_at = item.get("added_at")
+            if not isinstance(key, str) or not isinstance(path, str):
+                continue
+            if not isinstance(added_at, str):
+                added_at = ""
+            entries.append(MappingEntry(key=key, path=path, added_at=added_at))
+        self._entries = entries
+
+    def _atomic_write(self, payload: str) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile("w", delete=False, dir=str(self._path.parent), encoding="utf-8") as tmp:
+            tmp.write(payload)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp_path = Path(tmp.name)
+        os.replace(tmp_path, self._path)
+
+    def save(self) -> None:
+        payload = json.dumps([asdict(entry) for entry in self._entries], indent=2, ensure_ascii=False)
+        self._atomic_write(payload)
+
+    def list(self) -> List[MappingEntry]:
+        return self.entries
+
+    def add(self, key: str, directory: str, *, force: bool = False) -> MappingEntry:
+        self._ensure_valid_key(key)
+        resolved = self._canonicalize_path(directory)
+        if not resolved.exists() and not force:
+            raise InvalidSelectionError(f"Directory does not exist: {resolved}")
+        entry = MappingEntry(
+            key=key,
+            path=str(resolved),
+            added_at=datetime.now(timezone.utc).isoformat(),
+        )
+        for idx, existing in enumerate(self._entries):
+            if existing.key == key:
+                self._entries[idx] = entry
+                self.save()
+                return entry
+        self._entries.append(entry)
+        self.save()
+        return entry
+
+    def remove(self, identifier: str) -> MappingEntry:
+        if identifier.isdigit():
+            index = int(identifier)
+            if index < 1 or index > len(self._entries):
+                raise InvalidSelectionError("Mapping index out of range.")
+            removed = self._entries.pop(index - 1)
+        else:
+            for idx, entry in enumerate(self._entries):
+                if entry.key == identifier:
+                    removed = self._entries.pop(idx)
+                    break
+            else:
+                raise InvalidSelectionError(f"Unknown keyword: {identifier}")
+        self.save()
+        return removed
+
+    def clear(self) -> None:
+        self._entries.clear()
+        self.save()
+
+    def set_entries(self, entries: List[MappingEntry]) -> None:
+        self._entries = list(entries)
+        self.save()
+
+    def get(self, identifier: str) -> MappingEntry:
+        if identifier.isdigit():
+            index = int(identifier)
+            if index < 1 or index > len(self._entries):
+                raise InvalidSelectionError("Mapping index out of range.")
+            return self._entries[index - 1]
+        for entry in self._entries:
+            if entry.key == identifier:
+                return entry
+        raise InvalidSelectionError(f"Unknown keyword: {identifier}")
+
+    def keyword_exists(self, key: str) -> bool:
+        return any(entry.key == key for entry in self._entries)
+
+    def keywords(self) -> List[str]:
+        return [entry.key for entry in self._entries]
+
+    def export_per_key(self) -> dict[str, str]:
+        exports: dict[str, str] = {}
+        for entry in self._entries:
+            env_name = f"GDIR_{re.sub(r'[^A-Za-z0-9]', '_', entry.key).upper()}"
+            exports[env_name] = entry.path
+        return exports
+
+
+class History:
+    """Maintain navigation history with back/forward support."""
+
+    def __init__(self, history_path: Path, state_path: Path) -> None:
+        self._history_path = history_path
+        self._state_path = state_path
+        self._entries: List[HistoryEntry] = []
+        self._pointer: int = -1
+        self.load()
+
+    @property
+    def pointer(self) -> int:
+        return self._pointer
+
+    @property
+    def entries(self) -> List[HistoryEntry]:
+        return list(self._entries)
+
+    def load(self) -> None:
+        self._entries = []
+        self._pointer = -1
+        if self._history_path.exists():
+            lines = self._history_path.read_text(encoding="utf-8").splitlines()
+            for line in lines:
+                if not line.strip():
+                    continue
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                path = data.get("path")
+                visited_at = data.get("visited_at", "")
+                if isinstance(path, str):
+                    self._entries.append(HistoryEntry(path=path, visited_at=visited_at))
+        if self._state_path.exists():
+            try:
+                state = json.loads(self._state_path.read_text(encoding="utf-8"))
+                pointer = state.get("history_index", -1)
+                if isinstance(pointer, int):
+                    self._pointer = pointer
+            except json.JSONDecodeError:
+                self._pointer = len(self._entries) - 1
+        else:
+            self._pointer = len(self._entries) - 1
+        self._pointer = max(-1, min(self._pointer, len(self._entries) - 1))
+
+    def _atomic_write(self, path: Path, payload: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile("w", delete=False, dir=str(path.parent), encoding="utf-8") as tmp:
+            tmp.write(payload)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp_path = Path(tmp.name)
+        os.replace(tmp_path, path)
+
+    def save(self) -> None:
+        history_payload = "\n".join(json.dumps(asdict(entry), ensure_ascii=False) for entry in self._entries)
+        self._atomic_write(self._history_path, history_payload + ("\n" if history_payload else ""))
+        state_payload = json.dumps(
+            {
+                "history_index": self._pointer,
+                "last": self.prev_path(),
+                "next": self.next_path(),
+            },
+            indent=2,
+        )
+        self._atomic_write(self._state_path, state_payload)
+
+    def append(self, path: str) -> None:
+        timestamp = datetime.now(timezone.utc).isoformat()
+        if self._pointer < len(self._entries) - 1:
+            self._entries = self._entries[: self._pointer + 1]
+        self._entries.append(HistoryEntry(path=path, visited_at=timestamp))
+        self._pointer = len(self._entries) - 1
+        self.save()
+
+    def current_path(self) -> Optional[str]:
+        if 0 <= self._pointer < len(self._entries):
+            return self._entries[self._pointer].path
+        return None
+
+    def prev_path(self) -> Optional[str]:
+        if self._pointer > 0:
+            return self._entries[self._pointer - 1].path
+        return None
+
+    def next_path(self) -> Optional[str]:
+        if 0 <= self._pointer < len(self._entries) - 1:
+            return self._entries[self._pointer + 1].path
+        return None
+
+    def move_back(self, steps: int = 1) -> str:
+        if steps < 1:
+            raise UsageError("Steps must be a positive integer.")
+        target = self._pointer - steps
+        if target < 0:
+            raise InvalidSelectionError("Cannot move back any further.")
+        self._pointer = target
+        self.save()
+        return self._entries[self._pointer].path
+
+    def move_forward(self, steps: int = 1) -> str:
+        if steps < 1:
+            raise UsageError("Steps must be a positive integer.")
+        target = self._pointer + steps
+        if target >= len(self._entries):
+            raise InvalidSelectionError("Cannot move forward any further.")
+        self._pointer = target
+        self.save()
+        return self._entries[self._pointer].path
+
+    def window(self, before: int, after: int) -> List[tuple[int, HistoryEntry, bool]]:
+        if before < 0 or after < 0:
+            raise UsageError("Window sizes must be non-negative.")
+        start = max(0, self._pointer - before)
+        end = min(len(self._entries), self._pointer + after + 1)
+        result: List[tuple[int, HistoryEntry, bool]] = []
+        for idx in range(start, end):
+            entry = self._entries[idx]
+            is_current = idx == self._pointer
+            result.append((idx, entry, is_current))
+        return result
+
+
+def default_config_dir() -> Path:
+    override = os.environ.get(CONFIG_ENV_VAR)
+    if override:
+        return Path(override)
+    xdg_home = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_home:
+        return Path(xdg_home) / DEFAULT_DIRNAME
+    return Path.home() / ".config" / DEFAULT_DIRNAME
+
+
+def resolve_paths(config_dir: Optional[Path] = None) -> tuple[Path, Path, Path]:
+    base = config_dir or default_config_dir()
+    return (
+        base / "mappings.json",
+        base / "history.jsonl",
+        base / "state.json",
+    )
+
+

--- a/tests/test_gdir_cli.py
+++ b/tests/test_gdir_cli.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+
+def run_cli(tmp_config, *args):
+    env = os.environ.copy()
+    env["GDIR_CONFIG_DIR"] = str(tmp_config)
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, [str(Path.cwd() / "src"), env.get("PYTHONPATH")])
+    )
+    result = subprocess.run(
+        [sys.executable, "-m", "gdir", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    return result
+
+
+def test_add_go_and_env(tmp_path):
+    config_dir = tmp_path / "config"
+    target = tmp_path / "workspace"
+    target.mkdir()
+
+    add_result = run_cli(config_dir, "add", "code", str(target))
+    assert add_result.returncode == 0, add_result.stderr
+
+    go_result = run_cli(config_dir, "go", "code")
+    assert go_result.returncode == 0
+    assert go_result.stdout.strip() == str(target.resolve())
+
+    env_result = run_cli(config_dir, "env", "--format", "sh")
+    assert env_result.returncode == 0
+    lines = [line for line in env_result.stdout.splitlines() if line.startswith("export ")]
+    assert any(line.startswith("export GODIR_PREV=") for line in lines)
+    assert any(line.startswith("export GODIR_NEXT=") for line in lines)
+
+    list_result = run_cli(config_dir, "list")
+    assert "code" in list_result.stdout
+
+    hist_result = run_cli(config_dir, "hist")
+    assert str(target.resolve()) in hist_result.stdout
+
+    keywords_result = run_cli(config_dir, "keywords")
+    assert "code" in keywords_result.stdout.splitlines()
+
+
+def test_back_without_history(tmp_path):
+    config_dir = tmp_path / "config"
+    result = run_cli(config_dir, "back")
+    assert result.returncode == 2
+

--- a/tests/test_gdir_history.py
+++ b/tests/test_gdir_history.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import sys
+
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+import pytest
+
+from gdir.store import History
+from gdir.errors import InvalidSelectionError, UsageError
+
+
+def create_history(tmp_path):
+    config = tmp_path / 'config'
+    history_path = config / 'history.jsonl'
+    state_path = config / 'state.json'
+    return History(history_path, state_path)
+
+
+def test_back_forward_boundaries(tmp_path):
+    history = create_history(tmp_path)
+    history.append('/tmp/one')
+    history.append('/tmp/two')
+    history.append('/tmp/three')
+
+    assert history.current_path() == '/tmp/three'
+    assert history.move_back(2) == '/tmp/one'
+    with pytest.raises(InvalidSelectionError):
+        history.move_back()
+    assert history.move_forward(2) == '/tmp/three'
+    with pytest.raises(InvalidSelectionError):
+        history.move_forward()
+
+
+def test_window_render(tmp_path):
+    history = create_history(tmp_path)
+    for idx in range(1, 6):
+        history.append(f"/tmp/{idx}")
+    history.move_back()
+    window = history.window(2, 2)
+    assert len(window) == 4
+    indices = [idx for idx, _, _ in window]
+    assert indices == [1, 2, 3, 4]
+    markers = [flag for _, _, flag in window]
+    assert markers == [False, False, True, False]
+
+
+def test_invalid_step_value(tmp_path):
+    history = create_history(tmp_path)
+    history.append('/tmp/one')
+    with pytest.raises(UsageError):
+        history.move_back(0)
+    with pytest.raises(UsageError):
+        history.move_forward(0)
+    with pytest.raises(UsageError):
+        history.window(-1, 1)

--- a/tests/test_gdir_store.py
+++ b/tests/test_gdir_store.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import sys
+
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+import pytest
+
+from gdir.store import History, MappingStore
+from gdir.errors import InvalidSelectionError, UsageError
+
+
+def test_add_update_remove(tmp_path):
+    config = tmp_path / "config"
+    mapping_path = config / "mappings.json"
+    target = tmp_path / "workspace"
+    target.mkdir()
+
+    store = MappingStore(mapping_path)
+    entry = store.add("code", str(target))
+    assert entry.key == "code"
+    assert Path(entry.path) == target.resolve()
+
+    # Update keeps single entry
+    new_target = tmp_path / "workspace2"
+    new_target.mkdir()
+    updated = store.add("code", str(new_target))
+    assert len(store.list()) == 1
+    assert Path(updated.path) == new_target.resolve()
+
+    # Add another key and remove by index
+    store.add("docs", str(target))
+    assert {e.key for e in store.list()} == {"code", "docs"}
+
+    removed = store.remove("1")
+    assert removed.key == "code"
+    with pytest.raises(InvalidSelectionError):
+        store.get("code")
+
+    removed_keyword = store.remove("docs")
+    assert removed_keyword.key == "docs"
+    assert store.list() == []
+
+
+def test_invalid_key_and_path(tmp_path):
+    mapping_path = tmp_path / "config" / "mappings.json"
+    store = MappingStore(mapping_path)
+    with pytest.raises(UsageError):
+        store.add("bad key", str(tmp_path))
+    with pytest.raises(InvalidSelectionError):
+        store.add("code", str(tmp_path / "missing"))
+
+
+def test_force_allows_missing(tmp_path):
+    mapping_path = tmp_path / "config" / "mappings.json"
+    store = MappingStore(mapping_path)
+    entry = store.add("code", str(tmp_path / "missing"), force=True)
+    assert entry.key == "code"
+    assert store.get("code").path == entry.path
+
+
+def test_history_persistence(tmp_path):
+    config = tmp_path / "config"
+    history_path = config / "history.jsonl"
+    state_path = config / "state.json"
+
+    history = History(history_path, state_path)
+    history.append("/tmp/one")
+    history.append("/tmp/two")
+    assert history.current_path() == "/tmp/two"
+    assert history.move_back() == "/tmp/one"
+    assert history.move_forward() == "/tmp/two"
+
+    # Reload from disk preserves pointer and entries
+    reloaded = History(history_path, state_path)
+    assert reloaded.current_path() == "/tmp/two"
+    assert reloaded.prev_path() == "/tmp/one"


### PR DESCRIPTION
## Summary
- introduce the gdir Python package with a CLI for managing keyword-directory mappings, history navigation, environment exports, and imports
- add a persistence layer, error hierarchy, help text, and an installer script that wires shell wrappers and completions
- cover the new functionality with pytest suites for the mapping store, history handling, and CLI flows

## Testing
- pytest tests/test_gdir_store.py tests/test_gdir_history.py tests/test_gdir_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68f81c5875d08331b0b0bb9198a00f10