### PR TITLE
Add gdir command line navigation utility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=63", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gdir"
+version = "0.1.0"
+description = "Keyword-driven directory jumper"
+authors = [{ name = "PianoMan" }]
+readme = "README.md"
+requires-python = ">=3.9"
+
+[project.scripts]
+gdir = "gdir.cli:main"

--- a/scripts/gdir_install.sh
+++ b/scripts/gdir_install.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_SHELL="${1:-}"
+CONFIG_DIR="${GDIR_CONFIG:-$HOME/.config/gdir}"
+WRAPPER_BEGIN="# --- gdir wrapper (BEGIN MANAGED BLOCK) ---"
+WRAPPER_END="# --- gdir wrapper (END MANAGED BLOCK) ---"
+
+usage() {
+  cat <<USAGE
+Usage: gdir_install.sh [shell]
+
+Installs the gdir wrapper and completions for bash, zsh, or fish.
+If no shell is provided the script detects the current shell.
+USAGE
+}
+
+info() {
+  printf 'gdir install: %s\n' "$1"
+}
+
+ensure_config() {
+  mkdir -p "$CONFIG_DIR"
+}
+
+append_block() {
+  local file="$1"
+  local block="$2"
+  mkdir -p "$(dirname "$file")"
+  if [[ -f "$file" ]] && grep -Fq "$WRAPPER_BEGIN" "$file"; then
+    info "Wrapper already installed in $file"
+    return
+  fi
+  {
+    echo "$WRAPPER_BEGIN"
+    printf '%s\n' "$block"
+    echo "$WRAPPER_END"
+  } >>"$file"
+  info "Installed wrapper in $file"
+}
+
+install_bash() {
+  local rc="${HOME}/.bashrc"
+  local block='gdir() {
+  case "$1" in
+    go|back|fwd)
+      local target
+      target="$(command gdir "$@")" || return $?
+      [[ -z "$target" ]] && return 2
+      cd "$target" || return $?
+      eval "$(command gdir env --format sh)"
+      ;;
+    *)
+      command gdir "$@"
+      ;;
+  esac
+}
+trap 'command gdir save >/dev/null 2>&1' EXIT'
+  append_block "$rc" "$block"
+  install_completion_bash
+}
+
+install_zsh() {
+  local rc="${HOME}/.zshrc"
+  local block='gdir() {
+  case "$1" in
+    go|back|fwd)
+      local target
+      target="$(command gdir "$@")" || return $?
+      [[ -z "$target" ]] && return 2
+      cd "$target" || return $?
+      eval "$(command gdir env --format sh)"
+      ;;
+    *)
+      command gdir "$@"
+      ;;
+  esac
+}
+trap 'command gdir save >/dev/null 2>&1' EXIT'
+  append_block "$rc" "$block"
+  install_completion_zsh
+}
+
+install_fish() {
+  mkdir -p "$HOME/.config/fish/functions" "$HOME/.config/fish/completions"
+  local fn="$HOME/.config/fish/functions/gdir.fish"
+  local block='function gdir
+  set cmd $argv[1]
+  switch $cmd
+    case go back fwd
+      set target (command gdir $argv)
+      or return $status
+      if test -z "$target"
+        return 2
+      end
+      cd "$target"
+      command gdir env --format fish | source
+    case '*'
+      command gdir $argv
+  end
+end
+function __gdir_complete
+  command gdir list | awk 'NR>2 {print $2}'
+end
+complete -c gdir -f -a "(__gdir_complete)"'
+  printf '%s\n' "$block" >"$fn"
+  info "Installed fish function in $fn"
+}
+
+install_completion_bash() {
+  local dir="${HOME}/.local/share/gdir"
+  mkdir -p "$dir"
+  local file="$dir/gdir_completion.sh"
+  cat <<'COMP' >"$file"
+_gdir_complete() {
+  COMPREPLY=()
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  if [[ $COMP_CWORD -eq 1 ]]; then
+    COMPREPLY=( $(compgen -W "list add rm clear go back fwd hist env save load import pick doctor help" -- "$cur") )
+  elif [[ $COMP_CWORD -eq 2 && ${COMP_WORDS[1]} =~ ^(go|rm|back|fwd)$ ]]; then
+    local keys=$(command gdir list | awk 'NR>2 {print $2}')
+    COMPREPLY=( $(compgen -W "$keys" -- "$cur") )
+  fi
+}
+complete -F _gdir_complete gdir
+COMP
+  info "Installed bash completion in $file"
+}
+
+install_completion_zsh() {
+  local dir="${HOME}/.zsh/completions"
+  mkdir -p "$dir"
+  local file="$dir/_gdir"
+  cat <<'COMP' >"$file"
+#compdef gdir
+local -a subcommands
+subcommands=(list add rm clear go back fwd hist env save load import pick doctor help)
+local -a keywords
+keywords=($(command gdir list | awk 'NR>2 {print $2}'))
+_arguments '1: :->cmd' '2:keyword:->keyword'
+case $state in
+  cmd)
+    _describe -t commands 'gdir commands' subcommands ;;
+  keyword)
+    if [[ ${words[2]} == (go|rm|back|fwd) ]]; then
+      _describe -t keywords 'gdir keywords' keywords
+    fi ;;
+esac
+COMP
+  info "Installed zsh completion in $file"
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+ensure_config
+
+if [[ -z "$TARGET_SHELL" ]]; then
+  TARGET_SHELL=$(basename "${SHELL:-}")
+fi
+
+case "$TARGET_SHELL" in
+  bash)
+    install_bash ;;
+  zsh)
+    install_zsh ;;
+  fish)
+    install_fish ;;
+  *)
+    usage
+    exit 1 ;;
+esac
+
+info "Installation complete. Restart your shell to apply changes."

--- a/src/gdir/__init__.py
+++ b/src/gdir/__init__.py
@@ -1,0 +1,9 @@
+"""gdir package providing directory navigation helpers."""
+
+from .store import MappingStore, History, ConfigPaths  # noqa: F401
+
+__all__ = [
+    "MappingStore",
+    "History",
+    "ConfigPaths",
+]

--- a/src/gdir/cli.py
+++ b/src/gdir/cli.py
@@ -1,0 +1,463 @@
+"""Command line interface for the gdir utility."""
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from . import helptext
+from .store import ConfigPaths, History, MappingStore
+
+EXIT_OK = 0
+EXIT_INVALID = 2
+EXIT_USAGE = 64
+EXIT_TEMPFAIL = 75
+EXIT_INTERNAL = 70
+
+
+class CliError(Exception):
+    """Base exception that carries an exit code."""
+
+    def __init__(self, message: str, exit_code: int = EXIT_INTERNAL) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+class UserError(CliError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message, EXIT_INVALID)
+
+
+class UsageError(CliError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message, EXIT_USAGE)
+
+
+class TempFailure(CliError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message, EXIT_TEMPFAIL)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="gdir", add_help=False)
+    subparsers = parser.add_subparsers(dest="command")
+
+    parser.add_argument("--config", help="Override configuration directory")
+    parser.add_argument("-h", "--help", action="store_true", help="Show help text")
+
+    subparsers.add_parser("list")
+
+    add_cmd = subparsers.add_parser("add")
+    add_cmd.add_argument("key")
+    add_cmd.add_argument("path")
+    add_cmd.add_argument("--force", action="store_true", help="Allow adding non-existent directories")
+
+    rm_cmd = subparsers.add_parser("rm")
+    rm_cmd.add_argument("identifier")
+
+    clear_cmd = subparsers.add_parser("clear")
+    clear_cmd.add_argument("--yes", action="store_true", help="Do not prompt for confirmation")
+
+    go_cmd = subparsers.add_parser("go")
+    go_cmd.add_argument("identifier")
+
+    back_cmd = subparsers.add_parser("back")
+    back_cmd.add_argument("steps", nargs="?", type=int, default=1)
+
+    fwd_cmd = subparsers.add_parser("fwd")
+    fwd_cmd.add_argument("steps", nargs="?", type=int, default=1)
+
+    hist_cmd = subparsers.add_parser("hist")
+    hist_cmd.add_argument("--before", type=int, default=5)
+    hist_cmd.add_argument("--after", type=int, default=5)
+
+    env_cmd = subparsers.add_parser("env")
+    env_cmd.add_argument("--format", choices=("sh", "fish", "pwsh"), default="sh")
+    env_cmd.add_argument("--per-key", action="store_true", help="Emit per-key environment variables")
+
+    subparsers.add_parser("save")
+
+    load_cmd = subparsers.add_parser("load")
+    load_cmd.add_argument("file", nargs="?")
+
+    import_cmd = subparsers.add_parser("import")
+    import_cmd.add_argument("source", choices=("cdargs", "bashmarks"))
+    import_cmd.add_argument("--file", help="Override source file path")
+
+    pick_cmd = subparsers.add_parser("pick")
+    pick_cmd.add_argument("--fzf", help="Path to fzf executable")
+
+    subparsers.add_parser("doctor")
+    subparsers.add_parser("help")
+
+    return parser
+
+
+def _resolve_paths(args: argparse.Namespace) -> ConfigPaths:
+    if args.config:
+        return ConfigPaths(Path(args.config))
+    return ConfigPaths()
+
+
+def _load_store_and_history(paths: ConfigPaths) -> tuple[MappingStore, History]:
+    store = MappingStore(paths)
+    history = History(paths)
+    return store, history
+
+
+def _print_table(rows: List[Dict[str, str]]) -> None:
+    if not rows:
+        print("No mappings defined.")
+        return
+    index_width = max(len(str(row["index"])) for row in rows)
+    key_width = max(len(row["key"]) for row in rows)
+    header = f"{'index'.rjust(index_width)}  {'keyword'.ljust(key_width)}  directory"
+    print(header)
+    print("-" * len(header))
+    for row in rows:
+        index = row["index"].rjust(index_width)
+        key = row["key"].ljust(key_width)
+        directory = row["directory"]
+        print(f"{index}  {key}  {directory}")
+
+
+def _truncate_path(path: str, max_len: int = 80) -> str:
+    if len(path) <= max_len:
+        return path
+    keep = max_len - 3
+    front = keep // 2
+    back = keep - front
+    return f"{path[:front]}...{path[-back:]}"
+
+
+def _format_sh_env(env: Dict[str, str]) -> str:
+    lines = []
+    for key, value in env.items():
+        lines.append(f"export {key}={shlex.quote(value)}")
+    return "\n".join(lines)
+
+
+def _format_fish_env(env: Dict[str, str]) -> str:
+    lines = []
+    for key, value in env.items():
+        lines.append(f"set -gx {key} {shlex.quote(value)}")
+    return "\n".join(lines)
+
+
+def _format_pwsh_env(env: Dict[str, str]) -> str:
+    lines = []
+    for key, value in env.items():
+        escaped = value.replace("'", "''")
+        lines.append(f"$Env:{key} = '{escaped}'")
+    return "\n".join(lines)
+
+
+def _env_for_format(fmt: str, env: Dict[str, str]) -> str:
+    if fmt == "sh":
+        return _format_sh_env(env)
+    if fmt == "fish":
+        return _format_fish_env(env)
+    if fmt == "pwsh":
+        return _format_pwsh_env(env)
+    raise UsageError(f"Unsupported format {fmt}")
+
+
+def _prepare_env(store: MappingStore, history: History, *, per_key: bool) -> Dict[str, str]:
+    env: Dict[str, str] = {}
+    if history.previous is not None:
+        env["GODIR_PREV"] = str(history.previous)
+    if history.next is not None:
+        env["GODIR_NEXT"] = str(history.next)
+    if per_key:
+        for key, value in store.as_env().items():
+            env[f"GDIR_{_normalise_env_key(key)}"] = value
+    return env
+
+
+def _normalise_env_key(key: str) -> str:
+    sanitized = []
+    for ch in key:
+        if ch.isalnum():
+            sanitized.append(ch.upper())
+        else:
+            sanitized.append("_")
+    return "".join(sanitized)
+
+
+def _prompt_confirm(message: str) -> bool:
+    response = input(f"{message} [y/N]: ").strip().lower()
+    return response in {"y", "yes"}
+
+
+def _identifier_to_entry(store: MappingStore, identifier: str) -> Path:
+    try:
+        entry = store.resolve_identifier(identifier)
+    except KeyError:
+        raise UserError(f"Unknown mapping '{identifier}'.")
+    return entry.path
+
+
+def _handle_list(store: MappingStore) -> None:
+    rows = []
+    for idx, entry in enumerate(store.list()):
+        rows.append(
+            {
+                "index": str(idx),
+                "key": entry.key,
+                "directory": _truncate_path(str(entry.path)),
+            }
+        )
+    _print_table(rows)
+
+
+def _handle_add(store: MappingStore, key: str, path: str, *, force: bool) -> None:
+    try:
+        entry = store.add(key, Path(path), force=force)
+    except FileNotFoundError:
+        raise UserError(f"Directory does not exist: {path}")
+    except ValueError as exc:
+        raise UserError(str(exc))
+    print(f"Added {entry.key} -> {entry.path}")
+
+
+def _handle_rm(store: MappingStore, identifier: str) -> None:
+    try:
+        entry = store.remove(identifier)
+    except KeyError:
+        raise UserError(f"Unknown mapping '{identifier}'.")
+    print(f"Removed {entry.key}")
+
+
+def _handle_clear(store: MappingStore, *, assume_yes: bool) -> None:
+    if not assume_yes and not _prompt_confirm("Clear all mappings?"):
+        print("Aborted.")
+        return
+    store.clear()
+    print("Cleared all mappings.")
+
+
+def _handle_go(store: MappingStore, history: History, identifier: str) -> None:
+    path = _identifier_to_entry(store, identifier)
+    resolved = history.visit(path)
+    print(resolved)
+
+
+def _handle_back(history: History, steps: int) -> None:
+    target = history.back(max(1, steps))
+    if target is None:
+        raise UserError("Cannot move back that far.")
+    print(target)
+
+
+def _handle_fwd(history: History, steps: int) -> None:
+    target = history.forward(max(1, steps))
+    if target is None:
+        raise UserError("Cannot move forward that far.")
+    print(target)
+
+
+def _handle_hist(history: History, before: int, after: int) -> None:
+    window = history.window(max(0, before), max(0, after))
+    if not window:
+        print("History is empty.")
+        return
+    for idx, entry, is_current in window:
+        marker = "➤" if is_current else " "
+        print(f"{marker} {idx:>4} {entry.visited_at} {entry.path}")
+
+
+def _handle_env(store: MappingStore, history: History, fmt: str, *, per_key: bool) -> None:
+    env = _prepare_env(store, history, per_key=per_key)
+    output = _env_for_format(fmt, env)
+    if output:
+        print(output)
+
+
+def _handle_save(store: MappingStore, history: History) -> None:
+    store.save()
+    history.save()
+
+
+def _handle_load(store: MappingStore, history: History, file_path: Optional[str]) -> None:
+    if file_path:
+        src = Path(file_path).expanduser()
+        if not src.exists():
+            raise UserError(f"File not found: {file_path}")
+        data = json.loads(src.read_text(encoding="utf-8"))
+        if not isinstance(data, list):
+            raise UserError("Load file must contain a list of mappings.")
+        store.clear()
+        for item in data:
+            try:
+                key = item["key"]
+                path = item["path"]
+            except KeyError as exc:
+                raise UserError("Invalid mapping entry in load file.") from exc
+            store.add(str(key), Path(path), force=True)
+    store.reload()
+    history.reload()
+
+
+def _handle_import(store: MappingStore, source: str, override_file: Optional[str]) -> None:
+    if source == "cdargs":
+        path = Path(override_file or Path.home() / ".cdargs")
+        _import_cdargs(store, path)
+    elif source == "bashmarks":
+        path = Path(override_file or Path.home() / ".sdirs")
+        _import_bashmarks(store, path)
+    else:
+        raise UsageError(f"Unsupported import source: {source}")
+
+
+def _import_cdargs(store: MappingStore, path: Path) -> None:
+    if not path.exists():
+        raise UserError(f"cdargs file not found: {path}")
+    imported = 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(maxsplit=1)
+        if len(parts) != 2:
+            continue
+        key, directory = parts
+        try:
+            store.add(key, Path(directory), force=True)
+            imported += 1
+        except ValueError:
+            continue
+    print(f"Imported {imported} mappings from {path}")
+
+
+def _import_bashmarks(store: MappingStore, path: Path) -> None:
+    if not path.exists():
+        raise UserError(f"bashmarks file not found: {path}")
+    imported = 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or not line.startswith("export "):
+            continue
+        parts = line.split("=", 1)
+        if len(parts) != 2:
+            continue
+        key = parts[0].split()[-1]
+        value = parts[1].strip().strip('"').strip("'")
+        try:
+            store.add(key.lower(), Path(value), force=True)
+            imported += 1
+        except ValueError:
+            continue
+    print(f"Imported {imported} mappings from {path}")
+
+
+def _handle_pick(store: MappingStore, history: History, *, fzf: Optional[str]) -> None:
+    command = fzf or shutil.which("fzf")
+    if not command:
+        raise TempFailure("fzf not found; install fzf or pass --fzf.")
+    entries = store.list()
+    if not entries:
+        raise UserError("No mappings available to pick from.")
+    proc = subprocess.Popen(
+        [command],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.stdin is not None
+    for entry in entries:
+        proc.stdin.write(f"{entry.key}\t{entry.path}\n")
+    proc.stdin.close()
+    stdout, stderr = proc.communicate()
+    if proc.returncode != 0:
+        raise TempFailure(stderr.strip() or "Picker aborted.")
+    choice = stdout.strip()
+    if not choice:
+        raise TempFailure("No selection made.")
+    key = choice.split("\t", 1)[0]
+    _handle_go(store, history, key)
+
+
+def _handle_doctor(paths: ConfigPaths) -> None:
+    issues: List[str] = []
+    if not paths.root.exists():
+        issues.append(f"Config directory {paths.root} does not exist.")
+    for label, file in ("mappings", paths.mappings), ("history", paths.history), ("state", paths.state):
+        if not file.exists():
+            issues.append(f"{label} file missing: {file}")
+    if not issues:
+        print("All configuration files look good.")
+    else:
+        print("\n".join(issues))
+
+
+def _handle_help() -> None:
+    print(helptext.HELP_TEXT)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.help and not args.command:
+        _handle_help()
+        return EXIT_OK
+
+    if not args.command:
+        _handle_help()
+        return EXIT_USAGE
+
+    try:
+        paths = _resolve_paths(args)
+        store, history = _load_store_and_history(paths)
+
+        if args.command == "list":
+            _handle_list(store)
+        elif args.command == "add":
+            _handle_add(store, args.key, args.path, force=args.force)
+        elif args.command == "rm":
+            _handle_rm(store, args.identifier)
+        elif args.command == "clear":
+            _handle_clear(store, assume_yes=args.yes)
+        elif args.command == "go":
+            _handle_go(store, history, args.identifier)
+        elif args.command == "back":
+            _handle_back(history, args.steps)
+        elif args.command == "fwd":
+            _handle_fwd(history, args.steps)
+        elif args.command == "hist":
+            _handle_hist(history, args.before, args.after)
+        elif args.command == "env":
+            _handle_env(store, history, args.format, per_key=args.per_key)
+        elif args.command == "save":
+            _handle_save(store, history)
+        elif args.command == "load":
+            _handle_load(store, history, args.file)
+        elif args.command == "import":
+            _handle_import(store, args.source, args.file)
+        elif args.command == "pick":
+            _handle_pick(store, history, fzf=args.fzf)
+        elif args.command == "doctor":
+            _handle_doctor(paths)
+        elif args.command == "help":
+            _handle_help()
+        else:
+            raise UsageError(f"Unknown command {args.command}")
+        return EXIT_OK
+    except CliError as exc:
+        print(str(exc), file=sys.stderr)
+        return exc.exit_code
+    except KeyboardInterrupt:
+        return EXIT_TEMPFAIL
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        print(f"Internal error: {exc}", file=sys.stderr)
+        return EXIT_INTERNAL
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/gdir/helptext.py
+++ b/src/gdir/helptext.py
@@ -1,0 +1,28 @@
+"""Static help text used by the gdir CLI."""
+
+HELP_TEXT = """
+Usage: gdir <command> [options]
+
+Commands
+  list                     Show known mappings in a table
+  add <key> <path>         Add or update a mapping
+  rm <key|index>           Remove a mapping
+  clear [--yes]            Remove all mappings
+  go <key|index>           Resolve mapping and print absolute directory
+  back [N]                 Move backward in history and print location
+  fwd [N]                  Move forward in history and print location
+  hist [options]           Display history window (see --help for options)
+  env [options]            Emit shell environment exports
+  save                     Flush mappings and history to disk
+  load [file]              Reload state (optionally from a file)
+  import <source>          Import mappings from cdargs or bashmarks
+  pick                     Fuzzy pick a target (requires fzf)
+  doctor                   Inspect configuration files
+  help                     Show this message
+
+Examples
+  gdir add src ~/src/projects
+  cd "$(gdir go src)"
+  gdir back
+  eval "$(gdir env --format sh)"
+""".strip()

--- a/src/gdir/store.py
+++ b/src/gdir/store.py
@@ -1,0 +1,273 @@
+"""Persistence layer for the gdir command."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+from typing import Dict, List, Optional, Tuple
+from datetime import datetime, timezone
+
+_KEY_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class MappingEntry:
+    key: str
+    path: Path
+    added_at: str
+
+    def as_dict(self) -> Dict[str, str]:
+        return {"key": self.key, "path": str(self.path), "added_at": self.added_at}
+
+
+@dataclass
+class HistoryEntry:
+    path: Path
+    visited_at: str
+
+    def as_dict(self) -> Dict[str, str]:
+        return {"path": str(self.path), "visited_at": self.visited_at}
+
+
+class ConfigPaths:
+    """Utility that resolves configuration file locations."""
+
+    def __init__(self, root: Optional[Path] = None) -> None:
+        if root is None:
+            root = Path(os.environ.get("GDIR_CONFIG", Path.home() / ".config" / "gdir"))
+        self.root = Path(root)
+        self.mappings = self.root / "mappings.json"
+        self.history = self.root / "history.jsonl"
+        self.state = self.root / "state.json"
+
+    def ensure_root(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+
+
+class MappingStore:
+    """Maintains the keyword to directory mapping collection."""
+
+    def __init__(self, paths: Optional[ConfigPaths] = None) -> None:
+        self.paths = paths or ConfigPaths()
+        self.paths.ensure_root()
+        self._entries: List[MappingEntry] = []
+        self._load()
+
+    # ------------------------------------------------------------------
+    # basic operations
+    def _load(self) -> None:
+        if self.paths.mappings.exists():
+            data = json.loads(self.paths.mappings.read_text(encoding="utf-8"))
+            self._entries = [
+                MappingEntry(
+                    key=item["key"],
+                    path=Path(item["path"]),
+                    added_at=item.get("added_at") or _now_iso(),
+                )
+                for item in data
+            ]
+        else:
+            self._entries = []
+
+    def reload(self) -> None:
+        self._load()
+
+    def save(self) -> None:
+        self.paths.ensure_root()
+        payload = [entry.as_dict() for entry in self._entries]
+        _atomic_write(self.paths.mappings, json.dumps(payload, indent=2))
+
+    def list(self) -> List[MappingEntry]:
+        return list(self._entries)
+
+    def resolve_identifier(self, identifier: str) -> MappingEntry:
+        entry = self.get_by_key(identifier)
+        if entry:
+            return entry
+        try:
+            index = int(identifier)
+        except ValueError as exc:
+            raise KeyError(identifier) from exc
+        entry = self.get_by_index(index)
+        if entry:
+            return entry
+        raise KeyError(identifier)
+
+    def get_by_key(self, key: str) -> Optional[MappingEntry]:
+        for entry in self._entries:
+            if entry.key == key:
+                return entry
+        return None
+
+    def get_by_index(self, index: int) -> Optional[MappingEntry]:
+        if 0 <= index < len(self._entries):
+            return self._entries[index]
+        return None
+
+    def add(self, key: str, path: Path, *, force: bool = False) -> MappingEntry:
+        if not _KEY_PATTERN.match(key):
+            raise ValueError(f"Invalid key '{key}'. Keys may contain letters, numbers, dot, underscore, or dash.")
+        resolved = path.expanduser().resolve()
+        if not resolved.exists() and not force:
+            raise FileNotFoundError(str(resolved))
+        existing = self.get_by_key(key)
+        timestamp = _now_iso()
+        if existing:
+            existing.path = resolved
+            existing.added_at = timestamp
+            entry = existing
+        else:
+            entry = MappingEntry(key=key, path=resolved, added_at=timestamp)
+            self._entries.append(entry)
+        self.save()
+        return entry
+
+    def remove(self, identifier: str) -> MappingEntry:
+        entry = self.resolve_identifier(identifier)
+        self._entries = [e for e in self._entries if e is not entry]
+        self.save()
+        return entry
+
+    def clear(self) -> None:
+        self._entries.clear()
+        self.save()
+
+    def as_env(self) -> Dict[str, str]:
+        return {entry.key: str(entry.path) for entry in self._entries}
+
+
+class History:
+    """Tracks navigation history for gdir."""
+
+    def __init__(self, paths: Optional[ConfigPaths] = None) -> None:
+        self.paths = paths or ConfigPaths()
+        self.paths.ensure_root()
+        self._entries: List[HistoryEntry] = []
+        self._index: Optional[int] = None
+        self._load()
+
+    def _load(self) -> None:
+        entries: List[HistoryEntry] = []
+        if self.paths.history.exists():
+            for line in self.paths.history.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                entries.append(
+                    HistoryEntry(
+                        path=Path(data["path"]),
+                        visited_at=data.get("visited_at") or _now_iso(),
+                    )
+                )
+        self._entries = entries
+        index: Optional[int] = None
+        if self.paths.state.exists():
+            try:
+                state = json.loads(self.paths.state.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                state = {}
+            idx = state.get("history_index")
+            if isinstance(idx, int) and 0 <= idx < len(self._entries):
+                index = idx
+        if index is None and self._entries:
+            index = len(self._entries) - 1
+        self._index = index
+
+    def reload(self) -> None:
+        self._load()
+
+    def save(self) -> None:
+        self.paths.ensure_root()
+        lines = [json.dumps(entry.as_dict()) for entry in self._entries]
+        _atomic_write(self.paths.history, "\n".join(lines) + ("\n" if lines else ""))
+        state_payload = json.dumps({"history_index": self._index})
+        _atomic_write(self.paths.state, state_payload)
+
+    # navigation -------------------------------------------------------
+    def visit(self, path: Path) -> Path:
+        resolved = path.expanduser().resolve()
+        if self._index is not None and self._index < len(self._entries) - 1:
+            self._entries = self._entries[: self._index + 1]
+        entry = HistoryEntry(path=resolved, visited_at=_now_iso())
+        self._entries.append(entry)
+        self._index = len(self._entries) - 1
+        self.save()
+        return resolved
+
+    def back(self, steps: int = 1) -> Optional[Path]:
+        if not self._entries or self._index is None:
+            return None
+        new_index = self._index - steps
+        if new_index < 0:
+            return None
+        self._index = new_index
+        self.save()
+        return self._entries[self._index].path
+
+    def forward(self, steps: int = 1) -> Optional[Path]:
+        if not self._entries or self._index is None:
+            return None
+        new_index = self._index + steps
+        if new_index >= len(self._entries):
+            return None
+        self._index = new_index
+        self.save()
+        return self._entries[self._index].path
+
+    # information ------------------------------------------------------
+    @property
+    def current(self) -> Optional[Path]:
+        if self._index is None:
+            return None
+        return self._entries[self._index].path
+
+    @property
+    def previous(self) -> Optional[Path]:
+        if self._index is None:
+            return None
+        prev_index = self._index - 1
+        if prev_index < 0:
+            return None
+        return self._entries[prev_index].path
+
+    @property
+    def next(self) -> Optional[Path]:
+        if self._index is None:
+            return None
+        next_index = self._index + 1
+        if next_index >= len(self._entries):
+            return None
+        return self._entries[next_index].path
+
+    def window(self, before: int, after: int) -> List[Tuple[int, HistoryEntry, bool]]:
+        result: List[Tuple[int, HistoryEntry, bool]] = []
+        if not self._entries:
+            return result
+        if self._index is None:
+            window_indices = range(max(len(self._entries) - before - after - 1, 0), len(self._entries))
+        else:
+            start = max(self._index - before, 0)
+            end = min(self._index + after + 1, len(self._entries))
+            window_indices = range(start, end)
+        for idx in window_indices:
+            entry = self._entries[idx]
+            result.append((idx, entry, idx == self._index))
+        return result
+
+
+# ----------------------------------------------------------------------
+def _atomic_write(path: Path, data: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(data, encoding="utf-8")
+    os.replace(tmp_path, path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,71 @@
+from gdir import cli
+
+
+def run_cli(tmp_path, *args):
+    argv = ["--config", str(tmp_path)] + list(args)
+    return cli.main(argv)
+
+
+def test_add_and_go(tmp_path, capsys):
+    target = tmp_path / "destination"
+    target.mkdir()
+    code = run_cli(tmp_path, "add", "home", str(target))
+    assert code == 0
+    capsys.readouterr()
+    code = run_cli(tmp_path, "go", "home")
+    assert code == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() == str(target.resolve())
+
+
+def test_go_invalid_key(tmp_path, capsys):
+    code = run_cli(tmp_path, "go", "missing")
+    assert code == cli.EXIT_INVALID
+    captured = capsys.readouterr()
+    assert "Unknown mapping" in captured.err
+
+
+def test_env_output(tmp_path, capsys):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    run_cli(tmp_path, "add", "first", str(first))
+    run_cli(tmp_path, "add", "second", str(second))
+    capsys.readouterr()
+    run_cli(tmp_path, "go", "first")
+    capsys.readouterr()
+    run_cli(tmp_path, "go", "second")
+
+    code = run_cli(tmp_path, "env", "--format", "sh")
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "GODIR_PREV" in output
+    assert "GODIR_NEXT" not in output  # no forward entry yet
+
+    code = run_cli(tmp_path, "back")
+    assert code == 0
+    capsys.readouterr()
+    code = run_cli(tmp_path, "env", "--format", "sh")
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "GODIR_NEXT" in output
+
+
+def test_hist_command(tmp_path, capsys):
+    for idx in range(3):
+        folder = tmp_path / f"dir{idx}"
+        folder.mkdir()
+        run_cli(tmp_path, "add", f"k{idx}", str(folder))
+        run_cli(tmp_path, "go", f"k{idx}")
+        capsys.readouterr()
+    code = run_cli(tmp_path, "hist", "--before", "1", "--after", "1")
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "➤" in output
+
+
+def test_import_missing_file(tmp_path, capsys):
+    code = run_cli(tmp_path, "import", "cdargs")
+    assert code == cli.EXIT_INVALID
+    assert "cdargs file not found" in capsys.readouterr().err

--- a/tests/test_gdir_history.py
+++ b/tests/test_gdir_history.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import pytest
+
+from gdir.store import ConfigPaths, History
+
+
+def make_history(tmp_path):
+    paths = ConfigPaths(tmp_path)
+    return History(paths)
+
+
+def test_visit_trims_forward_history(tmp_path):
+    history = make_history(tmp_path)
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    third = tmp_path / "third"
+    for path in (first, second, third):
+        path.mkdir()
+
+    history.visit(first)
+    history.visit(second)
+    history.visit(third)
+
+    # walk back twice then visit new entry, should truncate tail
+    history.back()
+    history.back()
+    assert history.current == first.resolve()
+    history.visit(second)
+    assert history.current == second.resolve()
+    assert history.next is None
+
+
+def test_back_and_forward_bounds(tmp_path):
+    history = make_history(tmp_path)
+    location = tmp_path / "loc"
+    location.mkdir()
+
+    # history empty -> back/forward should return None
+    assert history.back() is None
+    assert history.forward() is None
+
+    history.visit(location)
+    assert history.back(2) is None
+    assert history.forward(2) is None
+
+
+def test_window_representation(tmp_path):
+    history = make_history(tmp_path)
+    for idx in range(5):
+        directory = tmp_path / f"dir{idx}"
+        directory.mkdir()
+        history.visit(directory)
+    window = history.window(2, 1)
+    # should include current plus two before and one after
+    assert window
+    indices = [idx for idx, _entry, _flag in window]
+    assert history.current == (tmp_path / "dir4").resolve()
+    assert window[-1][0] == 4
+    # ensure marker present for current item
+    assert any(flag for _i, _e, flag in window)

--- a/tests/test_gdir_store.py
+++ b/tests/test_gdir_store.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+import pytest
+
+from gdir.store import ConfigPaths, MappingStore
+
+
+def make_store(tmp_path):
+    paths = ConfigPaths(tmp_path)
+    return MappingStore(paths)
+
+
+def test_add_and_update(tmp_path):
+    store = make_store(tmp_path)
+    path = tmp_path / "alpha"
+    path.mkdir()
+    entry = store.add("alpha", path)
+    assert entry.key == "alpha"
+    assert entry.path == path.resolve()
+    assert len(store.list()) == 1
+
+    # Update existing mapping keeps index and overwrites path
+    new_path = tmp_path / "beta"
+    new_path.mkdir()
+    store.add("alpha", new_path)
+    items = store.list()
+    assert len(items) == 1
+    assert items[0].path == new_path.resolve()
+
+
+def test_remove_by_identifier(tmp_path):
+    store = make_store(tmp_path)
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    store.add("first", a)
+    store.add("second", b)
+
+    removed = store.remove("0")
+    assert removed.key == "first"
+    assert [entry.key for entry in store.list()] == ["second"]
+
+    removed = store.remove("second")
+    assert removed.key == "second"
+    assert store.list() == []
+
+
+def test_invalid_key(tmp_path):
+    store = make_store(tmp_path)
+    target = tmp_path / "folder"
+    target.mkdir()
+    with pytest.raises(ValueError):
+        store.add("bad key", target)
+
+
+def test_force_allows_missing(tmp_path):
+    store = make_store(tmp_path)
+    missing = tmp_path / "missing"
+    store.add("ghost", missing, force=True)
+    assert store.list()[0].path == missing.resolve()
+


### PR DESCRIPTION
## Summary
- add a gdir package that persists keyword mappings and navigation history
- implement a feature-rich CLI along with help text and shell installer helpers
- cover the new behavior with focused store, history, and CLI tests

## Testing
- pytest -q tests/test_gdir_store.py tests/test_gdir_history.py tests/test_cli_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68f81c5875d08331b0b0bb9198a00f10