### PR TITLE
Add gdir navigation tool variants

### DIFF
--- a/variants/A/README-Bias.md
+++ b/variants/A/README-Bias.md
@@ -1,0 +1,6 @@
+- SUBCOMMANDS+SINGLE-JSON: I wanted a compact persistence story, so one file
+  captures entries and history together. It simplified saving and load logic
+  and made the CLI feel familiar via named verbs.
+- LIST-FIXED: Fixed columns kept the listing deterministic and easy to scan in
+  smoke tests. The trade-off is aggressive truncation for very long paths, but
+  the predictable layout felt worth it here.

--- a/variants/A/README-variant.md
+++ b/variants/A/README-variant.md
@@ -1,0 +1,11 @@
+# Variant A – subcommand JSON jumper
+
+Variant A opts for a traditional subcommand-oriented CLI with a single JSON
+store written under `~/.config/gdir-a/`. Each run loads the store, performs the
+requested action, and saves the updated entries/history snapshot in one file.
+
+Listings follow a fixed-width layout that trades detail for predictable
+alignment, trimming long paths with a simple head/tail ellipsis. History is
+maintained alongside the entry data so that back/forward navigation carries
+across sessions without extra files. The `env` command sticks to the minimal
+PREV/NEXT exports, matching the shell wrapper expectation.

--- a/variants/A/src/gdir.py
+++ b/variants/A/src/gdir.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Variant A implementation of the gdir navigation helper."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+APP_NAME = "gdir-a"
+CONFIG_ENV = "GDIRA_CONFIG_HOME"
+DEFAULT_BEFORE = 5
+DEFAULT_AFTER = 5
+
+
+@dataclass
+class Entry:
+    key: str
+    path: str
+
+
+@dataclass
+class Store:
+    entries: List[Entry] = field(default_factory=list)
+    history: List[str] = field(default_factory=list)
+    pointer: int = -1
+
+    def to_json(self) -> Dict[str, object]:
+        return {
+            "entries": [entry.__dict__ for entry in self.entries],
+            "history": self.history,
+            "pointer": self.pointer,
+        }
+
+    @classmethod
+    def from_json(cls, payload: Dict[str, object]) -> "Store":
+        entries = [Entry(**item) for item in payload.get("entries", [])]
+        history = [str(x) for x in payload.get("history", [])]
+        pointer = int(payload.get("pointer", -1))
+        pointer = min(pointer, len(history) - 1)
+        return cls(entries=entries, history=history, pointer=pointer)
+
+
+def config_dir() -> Path:
+    root = os.environ.get(CONFIG_ENV)
+    if root:
+        base = Path(root).expanduser()
+    else:
+        base = Path.home() / ".config" / APP_NAME
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def data_path() -> Path:
+    return config_dir() / "store.json"
+
+
+def load_store() -> Store:
+    path = data_path()
+    if not path.exists():
+        return Store()
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except Exception:
+        raise SystemExit(70)
+    return Store.from_json(payload)
+
+
+def save_store(store: Store) -> None:
+    path = data_path()
+    tmp_path = path.with_suffix(".tmp")
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        json.dump(store.to_json(), handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    tmp_path.replace(path)
+
+
+def resolve_path(target: str) -> str:
+    resolved = Path(target).expanduser().resolve(strict=False)
+    return str(resolved)
+
+
+def find_entry(store: Store, key_or_index: str) -> Tuple[int, Entry]:
+    if key_or_index.isdigit():
+        idx = int(key_or_index) - 1
+        if idx < 0 or idx >= len(store.entries):
+            raise SystemExit(2)
+        return idx, store.entries[idx]
+    for idx, entry in enumerate(store.entries):
+        if entry.key == key_or_index:
+            return idx, entry
+    raise SystemExit(2)
+
+
+def ensure_unique(store: Store, key: str) -> None:
+    if any(entry.key == key for entry in store.entries):
+        print(f"key '{key}' already exists", file=sys.stderr)
+        raise SystemExit(64)
+
+
+def print_list(store: Store) -> None:
+    header = f"{'#':>3}  {'Key':<16}  Path"
+    print(header)
+    print("-" * len(header))
+    for idx, entry in enumerate(store.entries, start=1):
+        key = entry.key[:16]
+        path = entry.path
+        if len(path) > 60:
+            path = path[:28] + "…" + path[-31:]
+        print(f"{idx:>3}  {key:<16}  {path}")
+
+
+def cmd_list(store: Store, _args: argparse.Namespace) -> int:
+    print_list(store)
+    return 0
+
+
+def cmd_add(store: Store, args: argparse.Namespace) -> int:
+    ensure_unique(store, args.key)
+    path = resolve_path(args.directory)
+    store.entries.append(Entry(args.key, path))
+    print(f"added {args.key} -> {path}")
+    return 0
+
+
+def cmd_rm(store: Store, args: argparse.Namespace) -> int:
+    idx, _ = find_entry(store, args.target)
+    removed = store.entries.pop(idx)
+    print(f"removed {removed.key}")
+    return 0
+
+
+def cmd_clear(store: Store, args: argparse.Namespace) -> int:
+    if not args.yes:
+        confirmation = input("Type 'yes' to clear all entries: ")
+        if confirmation.strip().lower() != "yes":
+            print("aborted")
+            return 64
+    store.entries.clear()
+    print("cleared entries")
+    return 0
+
+
+def touch_history(store: Store, path: str) -> None:
+    if store.pointer < len(store.history) - 1:
+        store.history = store.history[: store.pointer + 1]
+    store.history.append(path)
+    store.pointer = len(store.history) - 1
+
+
+def cmd_go(store: Store, args: argparse.Namespace) -> int:
+    _, entry = find_entry(store, args.target)
+    path = resolve_path(entry.path)
+    if not Path(path).exists():
+        raise SystemExit(2)
+    touch_history(store, path)
+    print(path)
+    return 0
+
+
+def move_history(store: Store, steps: int) -> str:
+    if store.pointer < 0:
+        raise SystemExit(2)
+    new_pointer = store.pointer + steps
+    if new_pointer < 0 or new_pointer >= len(store.history):
+        raise SystemExit(2)
+    store.pointer = new_pointer
+    return store.history[store.pointer]
+
+
+def cmd_back(store: Store, args: argparse.Namespace) -> int:
+    steps = -args.steps
+    if args.steps <= 0:
+        return 64
+    path = move_history(store, steps)
+    print(path)
+    return 0
+
+
+def cmd_fwd(store: Store, args: argparse.Namespace) -> int:
+    steps = args.steps
+    if args.steps <= 0:
+        return 64
+    path = move_history(store, steps)
+    print(path)
+    return 0
+
+
+def history_window(store: Store, before: int, after: int) -> Iterable[Tuple[int, str, bool]]:
+    if store.pointer < 0:
+        return []
+    start = max(0, store.pointer - before)
+    end = min(len(store.history), store.pointer + after + 1)
+    for idx in range(start, end):
+        yield idx, store.history[idx], idx == store.pointer
+
+
+def cmd_hist(store: Store, args: argparse.Namespace) -> int:
+    rows = list(history_window(store, args.before, args.after))
+    if not rows:
+        print("(empty)")
+        return 0
+    for idx, path, current in rows:
+        marker = "->" if current else "  "
+        print(f"{marker} {idx + 1:>3}: {path}")
+    return 0
+
+
+def env_pair(name: str, value: Optional[str]) -> str:
+    safe = value or ""
+    return f"export {name}={shlex.quote(safe)}"
+
+
+def cmd_env(store: Store, _args: argparse.Namespace) -> int:
+    prev_path = None
+    next_path = None
+    if store.pointer > 0:
+        prev_path = store.history[store.pointer - 1]
+    if 0 <= store.pointer < len(store.history) - 1:
+        next_path = store.history[store.pointer + 1]
+    print(env_pair("PREV", prev_path))
+    print(env_pair("NEXT", next_path))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="gdir",
+        description="Directory jumper with keyword bindings.",
+        add_help=False,
+    )
+    parser.add_argument("--help", action="help", help="show this help message and exit")
+    subparsers = parser.add_subparsers(dest="command")
+
+    subparsers.add_parser("list", help="show entries").set_defaults(func=cmd_list)
+
+    add_p = subparsers.add_parser("add", help="add <key> <dir>")
+    add_p.add_argument("key")
+    add_p.add_argument("directory")
+    add_p.set_defaults(func=cmd_add)
+
+    rm_p = subparsers.add_parser("rm", help="remove <key|index>")
+    rm_p.add_argument("target")
+    rm_p.set_defaults(func=cmd_rm)
+
+    clear_p = subparsers.add_parser("clear", help="clear entries")
+    clear_p.add_argument("-y", "--yes", action="store_true", help="skip confirmation")
+    clear_p.set_defaults(func=cmd_clear)
+
+    go_p = subparsers.add_parser("go", help="go <key|index>")
+    go_p.add_argument("target")
+    go_p.set_defaults(func=cmd_go)
+
+    back_p = subparsers.add_parser("back", help="back [N]")
+    back_p.add_argument("steps", nargs="?", type=int, default=1)
+    back_p.set_defaults(func=cmd_back)
+
+    fwd_p = subparsers.add_parser("fwd", help="fwd [N]")
+    fwd_p.add_argument("steps", nargs="?", type=int, default=1)
+    fwd_p.set_defaults(func=cmd_fwd)
+
+    hist_p = subparsers.add_parser("hist", help="show history window")
+    hist_p.add_argument("--before", type=int, default=DEFAULT_BEFORE)
+    hist_p.add_argument("--after", type=int, default=DEFAULT_AFTER)
+    hist_p.set_defaults(func=cmd_hist)
+
+    env_p = subparsers.add_parser("env", help="print PREV/NEXT exports")
+    env_p.set_defaults(func=cmd_env)
+
+    example = (
+        "Examples:\n"
+        "  gdir add work ~/work/project\n"
+        "  cd \"$(gdir go work)\""
+    )
+    parser.epilog = example
+    return parser
+
+
+def run(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not getattr(args, "command", None):
+        parser.print_usage()
+        return 64
+    store = load_store()
+    try:
+        code = args.func(store, args)
+    except SystemExit as exc:
+        raise
+    except Exception:
+        return 70
+    if code == 0:
+        try:
+            save_store(store)
+        except Exception:
+            return 70
+    return code
+
+
+def main() -> None:
+    try:
+        code = run()
+    except SystemExit as exc:  # propagate explicit exit codes
+        raise
+    except Exception:
+        code = 70
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/variants/A/tests/test_smoke.py
+++ b/variants/A/tests/test_smoke.py
@@ -1,0 +1,130 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "src" / "gdir.py"
+
+
+def run(cmd, env, input_text=None, check=False):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)] + cmd,
+        input=input_text,
+        text=True,
+        capture_output=True,
+        env=env,
+        cwd=SCRIPT.parent.parent,
+    )
+    if check:
+        result.check_returncode()
+    return result
+
+
+def make_env(tmp_path):
+    env = os.environ.copy()
+    env["GDIRA_CONFIG_HOME"] = str(tmp_path / "config")
+    return env
+
+
+def test_add_list_rm_clear(tmp_path):
+    env = make_env(tmp_path)
+    base = tmp_path / "dirs"
+    (base / "one").mkdir(parents=True)
+    (base / "two").mkdir()
+
+    out = run(["list"], env, check=True)
+    assert "Key" in out.stdout
+
+    run(["add", "one", str(base / "one")], env, check=True)
+    run(["add", "two", str(base / "two")], env, check=True)
+
+    listing = run(["list"], env, check=True).stdout.strip().splitlines()
+    assert listing[2].startswith("  1  one")
+    assert listing[3].startswith("  2  two")
+
+    run(["rm", "1"], env, check=True)
+    listing = run(["list"], env, check=True).stdout.strip().splitlines()
+    assert listing[2].startswith("  1  two")
+
+    run(["clear", "--yes"], env, check=True)
+    listing = run(["list"], env, check=True).stdout.strip().splitlines()
+    assert len(listing) == 2
+
+
+def test_navigation_and_errors(tmp_path):
+    env = make_env(tmp_path)
+    base = tmp_path / "nav"
+    (base / "alpha").mkdir(parents=True)
+    (base / "beta").mkdir()
+
+    run(["add", "a", str(base / "alpha")], env, check=True)
+    run(["add", "b", str(base / "beta")], env, check=True)
+
+    go_a = run(["go", "a"], env)
+    assert go_a.returncode == 0
+    assert go_a.stdout.strip() == str((base / "alpha").resolve())
+
+    go_b = run(["go", "2"], env)
+    assert go_b.stdout.strip() == str((base / "beta").resolve())
+
+    back = run(["back"], env)
+    assert back.stdout.strip() == str((base / "alpha").resolve())
+
+    fwd = run(["fwd", "1"], env)
+    assert fwd.stdout.strip() == str((base / "beta").resolve())
+
+    missing = run(["go", "zzz"], env)
+    assert missing.returncode == 2
+    assert missing.stdout == ""
+
+
+def test_history_persists_across_invocations(tmp_path):
+    env = make_env(tmp_path)
+    base = tmp_path / "hist"
+    (base / "one").mkdir(parents=True)
+    (base / "two").mkdir()
+
+    run(["add", "one", str(base / "one")], env, check=True)
+    run(["add", "two", str(base / "two")], env, check=True)
+
+    run(["go", "one"], env, check=True)
+    run(["go", "two"], env, check=True)
+
+    hist_output = run(["hist", "--before", "2", "--after", "2"], env, check=True).stdout
+    assert "->" in hist_output
+
+    back = run(["back"], env)
+    assert back.stdout.strip().endswith("one")
+
+    # new process uses stored pointer
+    fwd = run(["fwd"], env)
+    assert fwd.stdout.strip().endswith("two")
+
+
+def test_env_exports(tmp_path):
+    env = make_env(tmp_path)
+    base = tmp_path / "env"
+    (base / "p").mkdir(parents=True)
+    (base / "q").mkdir()
+
+    run(["add", "p", str(base / "p")], env, check=True)
+    run(["add", "q", str(base / "q")], env, check=True)
+
+    run(["go", "p"], env, check=True)
+    run(["go", "q"], env, check=True)
+
+    output = run(["env"], env, check=True).stdout.strip().splitlines()
+    assert output[0].startswith("export PREV=")
+    assert output[1].startswith("export NEXT=")
+
+
+def test_help_and_usage(tmp_path):
+    env = make_env(tmp_path)
+    help_out = run(["--help"], env)
+    assert help_out.returncode == 0
+    assert "Examples" in help_out.stdout
+
+    usage = run([], env)
+    assert usage.returncode == 64
+    assert "usage" in usage.stdout.lower()

--- a/variants/A/wrapper.sh
+++ b/variants/A/wrapper.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+# Minimal wrapper for Variant A
+
+DIR=$(CDPATH=; cd "$(dirname "$0")" && pwd)
+exec python3 "$DIR/src/gdir.py" "$@"
+
+# Example: cd "$(./wrapper.sh go work)"

--- a/variants/B/README-Bias.md
+++ b/variants/B/README-Bias.md
@@ -1,0 +1,5 @@
+- FLAGS+JSONL+STATE: The CLI defaults to short flags and keeps entries/history
+  in JSONL files with a separate `state.json` pointer. It made each run append-
+  friendly while keeping the history pointer easy to inspect and tweak.
+- ENV-RICH: `gdir -e` prints PREV/NEXT, and `--keys` opts into per-key exports,
+  giving shell users richer context when they want it without forcing extras.

--- a/variants/B/README-variant.md
+++ b/variants/B/README-variant.md
@@ -1,0 +1,12 @@
+# Variant B – flag-driven JSONL jumper
+
+Variant B embraces short flags for every action so it works well in compact
+aliases such as `gdir -g wk`. Persistence lives in JSONL files: `entries.jsonl`
+captures the keyword table while `history.jsonl` records jumps. A separate
+`state.json` file keeps the live pointer, matching the bias toward an explicit
+state file.
+
+The history-aware commands reuse those files across sessions, and the `env`
+action can emit rich exports (PREV/NEXT plus per-key entries when requested).
+Listings widen columns based on the observed data but clamp overly long paths
+with a centered ellipsis.

--- a/variants/B/src/gdir.py
+++ b/variants/B/src/gdir.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Variant B implementation with flag-centric CLI and JSONL persistence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+
+APP_NAME = "gdir-b"
+CONFIG_ENV = "GDIRB_CONFIG_HOME"
+
+
+@dataclass
+class Entry:
+    key: str
+    path: str
+
+
+def config_dir() -> Path:
+    root = os.environ.get(CONFIG_ENV)
+    if root:
+        base = Path(root).expanduser()
+    else:
+        base = Path.home() / ".config" / APP_NAME
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def entries_path() -> Path:
+    return config_dir() / "entries.jsonl"
+
+
+def history_path() -> Path:
+    return config_dir() / "history.jsonl"
+
+
+def state_path() -> Path:
+    return config_dir() / "state.json"
+
+
+def load_entries() -> List[Entry]:
+    path = entries_path()
+    entries: List[Entry] = []
+    if not path.exists():
+        return entries
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            if payload.get("deleted"):
+                entries = [e for e in entries if e.key != payload["key"]]
+            else:
+                entries = [e for e in entries if e.key != payload["key"]]
+                entries.append(Entry(payload["key"], payload["path"]))
+    return entries
+
+
+def save_entries(entries: List[Entry]) -> None:
+    path = entries_path()
+    tmp = path.with_suffix(".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        for entry in entries:
+            handle.write(json.dumps({"key": entry.key, "path": entry.path}) + "\n")
+    tmp.replace(path)
+
+
+def load_history() -> Tuple[List[str], int]:
+    history_file = history_path()
+    state_file = state_path()
+    history: List[str] = []
+    pointer = -1
+    if history_file.exists():
+        with history_file.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if line:
+                    history.append(json.loads(line)["path"])
+    if state_file.exists():
+        try:
+            payload = json.loads(state_file.read_text())
+            pointer = int(payload.get("pointer", -1))
+        except Exception:
+            pointer = -1
+    pointer = min(pointer, len(history) - 1)
+    return history, pointer
+
+
+def save_history(history: List[str], pointer: int) -> None:
+    history_file = history_path()
+    tmp_history = history_file.with_suffix(".tmp")
+    with tmp_history.open("w", encoding="utf-8") as handle:
+        for item in history:
+            handle.write(json.dumps({"path": item}) + "\n")
+    tmp_history.replace(history_file)
+
+    state_file = state_path()
+    tmp_state = state_file.with_suffix(".tmp")
+    with tmp_state.open("w", encoding="utf-8") as handle:
+        json.dump({"pointer": pointer}, handle)
+        handle.write("\n")
+    tmp_state.replace(state_file)
+
+
+def resolve_path(target: str) -> str:
+    return str(Path(target).expanduser().resolve(strict=False))
+
+
+def find_entry(entries: List[Entry], token: str) -> Entry:
+    if token.isdigit():
+        idx = int(token) - 1
+        if idx < 0 or idx >= len(entries):
+            raise SystemExit(2)
+        return entries[idx]
+    for entry in entries:
+        if entry.key == token:
+            return entry
+    raise SystemExit(2)
+
+
+def ensure_unique(entries: List[Entry], key: str) -> None:
+    if any(entry.key == key for entry in entries):
+        print(f"key '{key}' exists", file=sys.stderr)
+        raise SystemExit(64)
+
+
+def print_list(entries: List[Entry]) -> None:
+    if not entries:
+        print("(empty)")
+        return
+    key_width = max(8, max(len(entry.key) for entry in entries))
+    path_limit = min(60, max(len(entry.path) for entry in entries))
+    header = f"{'#':>3}  {'Key':<{key_width}}  Path"
+    print(header)
+    print("-" * len(header))
+    for idx, entry in enumerate(entries, start=1):
+        key = entry.key.ljust(key_width)
+        path = entry.path
+        if len(path) > path_limit:
+            head = max(4, path_limit // 2)
+            tail = max(4, path_limit - head - 1)
+            path = f"{path[:head]}…{path[-tail:]}"
+        print(f"{idx:>3}  {key}  {path}")
+
+
+def touch_history(history: List[str], pointer: int, path: str) -> Tuple[List[str], int]:
+    if pointer < len(history) - 1:
+        history = history[: pointer + 1]
+    history.append(path)
+    pointer = len(history) - 1
+    return history, pointer
+
+
+def move_pointer(history: List[str], pointer: int, delta: int) -> Tuple[str, int]:
+    if pointer < 0:
+        raise SystemExit(2)
+    new_pointer = pointer + delta
+    if new_pointer < 0 or new_pointer >= len(history):
+        raise SystemExit(2)
+    return history[new_pointer], new_pointer
+
+
+def env_name(key: str) -> str:
+    cleaned = [ch if ch.isalnum() else "_" for ch in key.upper()]
+    return "GDIR_" + "".join(cleaned)
+
+
+def env_lines(history: List[str], pointer: int, entries: List[Entry], include_keys: bool) -> List[str]:
+    prev_val = history[pointer - 1] if pointer > 0 else ""
+    next_val = history[pointer + 1] if 0 <= pointer < len(history) - 1 else ""
+    lines = [
+        f"export PREV={shlex.quote(prev_val)}",
+        f"export NEXT={shlex.quote(next_val)}",
+    ]
+    if include_keys:
+        for entry in entries:
+            lines.append(f"export {env_name(entry.key)}={shlex.quote(entry.path)}")
+    return lines
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="gdir",
+        description="Keyword directory jumper (flag-oriented variant).",
+        add_help=False,
+    )
+    parser.add_argument("-h", "--help", action="help", help="show help and exit")
+
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument("-l", "--list", action="store_true", help="list entries")
+    group.add_argument("-a", "--add", nargs=2, metavar=("KEY", "DIR"), help="add mapping")
+    group.add_argument("-r", "--rm", metavar="TARGET", help="remove entry")
+    group.add_argument("-c", "--clear", action="store_true", help="clear entries")
+    group.add_argument("-g", "--go", metavar="TARGET", help="jump to entry")
+    group.add_argument("-b", "--back", nargs="?", const="1", metavar="N", help="step back")
+    group.add_argument("-f", "--fwd", nargs="?", const="1", metavar="N", help="step forward")
+    group.add_argument("-H", "--hist", action="store_true", help="show history")
+    group.add_argument("-e", "--env", action="store_true", help="print exports")
+
+    parser.add_argument("--before", type=int, default=5, help="history items before pointer")
+    parser.add_argument("--after", type=int, default=5, help="history items after pointer")
+    parser.add_argument("-y", "--yes", action="store_true", help="confirm clearing")
+    parser.add_argument("--keys", action="store_true", help="include per-key exports")
+
+    parser.add_argument("command", nargs="*", help=argparse.SUPPRESS)
+
+    parser.epilog = (
+        "Examples:\n"
+        "  gdir -a wk ~/work\n"
+        "  cd \"$(gdir -g wk)\""
+    )
+    return parser
+
+
+def deduce_action(args: argparse.Namespace) -> str:
+    if args.list:
+        return "list"
+    if args.add:
+        return "add"
+    if args.rm:
+        return "rm"
+    if args.clear:
+        return "clear"
+    if args.go:
+        return "go"
+    if args.back is not None:
+        return "back"
+    if args.fwd is not None:
+        return "fwd"
+    if args.hist:
+        return "hist"
+    if args.env:
+        return "env"
+    if args.command:
+        return args.command[0]
+    return ""
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    action = deduce_action(args)
+    if not action:
+        parser.print_usage()
+        return 64
+
+    try:
+        entries = load_entries()
+        history, pointer = load_history()
+    except Exception:
+        return 70
+
+    try:
+        if action == "list":
+            print_list(entries)
+            code = 0
+        elif action == "add":
+            key, directory = args.add if args.add else args.command[1:3]
+            if not args.add and len(args.command) < 3:
+                return 64
+            ensure_unique(entries, key)
+            path = resolve_path(directory)
+            entries.append(Entry(key, path))
+            code = 0
+        elif action == "rm":
+            target = args.rm or (args.command[1] if len(args.command) > 1 else "")
+            if not target:
+                return 64
+            entry = find_entry(entries, target)
+            entries = [e for e in entries if e.key != entry.key]
+            code = 0
+        elif action == "clear":
+            if not args.yes:
+                response = input("Type 'yes' to clear all entries: ")
+                if response.strip().lower() != "yes":
+                    print("aborted")
+                    return 64
+            entries = []
+            code = 0
+        elif action == "go":
+            target = args.go or (args.command[1] if len(args.command) > 1 else "")
+            if not target:
+                return 64
+            entry = find_entry(entries, target)
+            path = resolve_path(entry.path)
+            if not Path(path).exists():
+                raise SystemExit(2)
+            history, pointer = touch_history(history, pointer, path)
+            print(path)
+            code = 0
+        elif action == "back":
+            if args.back is not None:
+                steps = int(args.back)
+            else:
+                steps = int(args.command[1]) if len(args.command) > 1 else 1
+            if steps <= 0:
+                return 64
+            path, pointer = move_pointer(history, pointer, -steps)
+            print(path)
+            code = 0
+        elif action == "fwd":
+            if args.fwd is not None:
+                steps = int(args.fwd)
+            else:
+                steps = int(args.command[1]) if len(args.command) > 1 else 1
+            if steps <= 0:
+                return 64
+            path, pointer = move_pointer(history, pointer, steps)
+            print(path)
+            code = 0
+        elif action == "hist":
+            before = args.before
+            after = args.after
+            if pointer < 0:
+                print("(empty)")
+            else:
+                start = max(0, pointer - before)
+                end = min(len(history), pointer + after + 1)
+                for idx in range(start, end):
+                    marker = "->" if idx == pointer else "  "
+                    print(f"{marker} {idx + 1:>3}: {history[idx]}")
+            code = 0
+        elif action == "env":
+            include_keys = args.keys
+            for line in env_lines(history, pointer, entries, include_keys):
+                print(line)
+            code = 0
+        else:
+            return 64
+    except SystemExit as exc:
+        return exc.code if isinstance(exc.code, int) else 70
+    except Exception:
+        return 70
+
+    if code == 0:
+        try:
+            save_entries(entries)
+            save_history(history, pointer)
+        except Exception:
+            return 70
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/variants/B/tests/test_smoke.py
+++ b/variants/B/tests/test_smoke.py
@@ -1,0 +1,136 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+import json
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "src" / "gdir.py"
+
+
+def run(cmd, env, input_text=None, check=False):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)] + cmd,
+        input=input_text,
+        text=True,
+        capture_output=True,
+        env=env,
+        cwd=SCRIPT.parent.parent,
+    )
+    if check:
+        result.check_returncode()
+    return result
+
+
+def make_env(tmp_path):
+    env = os.environ.copy()
+    env["GDIRB_CONFIG_HOME"] = str(tmp_path / "cfg")
+    return env
+
+
+def test_add_list_rm_clear(tmp_path):
+    env = make_env(tmp_path)
+    base = tmp_path / "dirs"
+    (base / "one").mkdir(parents=True)
+    (base / "two").mkdir()
+
+    empty = run(["-l"], env, check=True)
+    assert "(empty)" in empty.stdout
+
+    run(["-a", "one", str(base / "one")], env, check=True)
+    run(["-a", "two", str(base / "two")], env, check=True)
+
+    listing = run(["-l"], env, check=True).stdout.strip().splitlines()
+    assert listing[2].startswith("  1  one")
+    assert listing[3].startswith("  2  two")
+
+    run(["-r", "1"], env, check=True)
+    listing = run(["-l"], env, check=True).stdout.strip().splitlines()
+    assert listing[2].startswith("  1  two")
+
+    run(["-c", "-y"], env, check=True)
+    assert "(empty)" in run(["-l"], env, check=True).stdout
+
+
+def test_navigation_and_errors(tmp_path):
+    env = make_env(tmp_path)
+    base = tmp_path / "nav"
+    (base / "alpha").mkdir(parents=True)
+    (base / "beta").mkdir()
+
+    run(["-a", "a", str(base / "alpha")], env, check=True)
+    run(["-a", "b", str(base / "beta")], env, check=True)
+
+    go_a = run(["-g", "a"], env)
+    assert go_a.stdout.strip() == str((base / "alpha").resolve())
+
+    go_b = run(["-g", "2"], env)
+    assert go_b.stdout.strip() == str((base / "beta").resolve())
+
+    back = run(["-b"], env)
+    assert back.stdout.strip().endswith("alpha")
+
+    fwd = run(["-f", "1"], env)
+    assert fwd.stdout.strip().endswith("beta")
+
+    missing = run(["-g", "zzz"], env)
+    assert missing.returncode == 2
+    assert missing.stdout == ""
+
+
+def test_history_persists(tmp_path):
+    env = make_env(tmp_path)
+    base = tmp_path / "hist"
+    (base / "one").mkdir(parents=True)
+    (base / "two").mkdir()
+
+    run(["-a", "one", str(base / "one")], env, check=True)
+    run(["-a", "two", str(base / "two")], env, check=True)
+
+    run(["-g", "one"], env, check=True)
+    run(["-g", "two"], env, check=True)
+
+    hist = run(["-H", "--before", "2", "--after", "2"], env, check=True).stdout
+    assert "->" in hist
+
+    back = run(["-b"], env)
+    assert back.stdout.strip().endswith("one")
+
+    # pointer stored in state file and reused
+    state = json.loads((tmp_path / "cfg" / "state.json").read_text())
+    assert state["pointer"] >= 0
+
+    fwd = run(["-f"], env)
+    assert fwd.stdout.strip().endswith("two")
+
+
+def test_env_rich_exports(tmp_path):
+    env = make_env(tmp_path)
+    base = tmp_path / "env"
+    (base / "p").mkdir(parents=True)
+    (base / "q").mkdir()
+
+    run(["-a", "p", str(base / "p")], env, check=True)
+    run(["-a", "q", str(base / "q")], env, check=True)
+
+    run(["-g", "p"], env, check=True)
+    run(["-g", "q"], env, check=True)
+
+    minimal = run(["-e"], env, check=True).stdout.strip().splitlines()
+    assert minimal[0].startswith("export PREV=")
+    assert minimal[1].startswith("export NEXT=")
+
+    rich = run(["-e", "--keys"], env, check=True).stdout.strip().splitlines()
+    assert any(line.startswith("export GDIR_P=") for line in rich)
+    assert any(line.startswith("export GDIR_Q=") for line in rich)
+
+
+def test_help_and_usage(tmp_path):
+    env = make_env(tmp_path)
+    help_out = run(["-h"], env)
+    assert help_out.returncode == 0
+    assert "Examples" in help_out.stdout
+
+    usage = run([], env)
+    assert usage.returncode == 64
+    assert "usage" in usage.stdout.lower()

--- a/variants/B/wrapper.sh
+++ b/variants/B/wrapper.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+# Minimal wrapper for Variant B
+
+DIR=$(CDPATH=; cd "$(dirname "$0")" && pwd)
+exec python3 "$DIR/src/gdir.py" "$@"
+
+# Example: cd "$(./wrapper.sh -g work)"


### PR DESCRIPTION
## Summary
- add Variant A gdir implementation with subcommand CLI, single JSON store, and fixed-width listings
- add Variant B gdir implementation with flag-first CLI, JSONL persistence, and rich env exports
- include smoke tests, bias notes, and wrappers demonstrating cd usage for both variants

## Testing
- pytest -q (variants/A)
- pytest -q (variants/B)


------
https://chatgpt.com/codex/tasks/task_e_68f95aed8f648331a76d9306c0ffedeb