### PR TITLE
Add gdir directory jumper variants A and B

### DIFF
--- a/variants/A/README-Bias.md
+++ b/variants/A/README-Bias.md
@@ -1,0 +1,4 @@
+# Bias Choices
+
+- **SUBCOMMANDS+SINGLE-JSON** — I leaned into a subcommand-oriented UX so each action is explicit and argparse can emit rich help. Consolidating everything into one JSON file made state saves straightforward and kept persistence easy to inspect.
+- **LIST-ADAPTIVE** — Adaptive column widths with mid-ellipsis keep `gdir list` readable even when paths are long, while still showing distinguishing prefixes/suffixes. It nudged me to separate presentation concerns from the storage layer.

--- a/variants/A/README-variant.md
+++ b/variants/A/README-variant.md
@@ -1,0 +1,3 @@
+# Variant A
+
+Variant A implements `gdir` with subcommands and a single JSON file for persistence. Subcommands keep the interface explicit (`gdir add`, `gdir go`, etc.) and make help/usage straightforward. All state, including bookmarks and history, lives in one structured file, simplifying atomic saves. Listing output adapts column widths and shortens long paths with mid-ellipsis to keep the view compact yet informative. History is trimmed when jumping after a backtrack so navigation feels natural. The CLI returns absolute paths only for navigation commands, enabling shell wrappers like `cd "$(gdir go proj)"`.

--- a/variants/A/src/gdir.py
+++ b/variants/A/src/gdir.py
@@ -1,0 +1,362 @@
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+CONFIG_DIR_NAME = "gdirA"
+STATE_FILE_NAME = "state.json"
+
+
+class UsageArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        self.print_usage(sys.stderr)
+        self.exit(64, f"{self.prog}: error: {message}\n")
+
+
+class DomainError(Exception):
+    """Raised when the requested target or selection is invalid."""
+
+
+@dataclass
+class State:
+    bookmarks: Dict[str, str]
+    history: List[str]
+    pointer: int
+
+    @staticmethod
+    def empty() -> "State":
+        return State({}, [], -1)
+
+
+def config_dir() -> Path:
+    base = os.environ.get("XDG_CONFIG_HOME")
+    if base:
+        root = Path(base)
+    else:
+        root = Path.home() / ".config"
+    return root / CONFIG_DIR_NAME
+
+
+def state_path() -> Path:
+    return config_dir() / STATE_FILE_NAME
+
+
+def load_state() -> State:
+    path = state_path()
+    if not path.exists():
+        return State.empty()
+    try:
+        data = json.loads(path.read_text())
+        bookmarks = data.get("bookmarks", {})
+        history = data.get("history", [])
+        pointer = data.get("pointer", -1)
+        # ensure keys and paths are strings and absolute
+        normalized: Dict[str, str] = {}
+        for key, value in bookmarks.items():
+            if isinstance(key, str) and isinstance(value, str):
+                normalized[key] = value
+        hist_list = [entry for entry in history if isinstance(entry, str)]
+        if not isinstance(pointer, int):
+            pointer = len(hist_list) - 1
+        return State(normalized, hist_list, pointer)
+    except json.JSONDecodeError:
+        return State.empty()
+
+
+def ensure_config_dir() -> None:
+    config_dir().mkdir(parents=True, exist_ok=True)
+
+
+def save_state(state: State) -> None:
+    ensure_config_dir()
+    payload = {
+        "bookmarks": state.bookmarks,
+        "history": state.history,
+        "pointer": state.pointer,
+    }
+    path = state_path()
+    tmp_path = path.with_suffix(".tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    tmp_path.replace(path)
+
+
+def absolute_path(value: str) -> str:
+    return str(Path(value).expanduser().resolve())
+
+
+def parse_target(state: State, target: str) -> Tuple[str, str]:
+    """Return (key, path) for the requested target."""
+    if target.isdigit():
+        index = int(target)
+        keys = sorted(state.bookmarks)
+        if index < 1 or index > len(keys):
+            raise DomainError("index out of range")
+        key = keys[index - 1]
+        return key, state.bookmarks[key]
+    if target in state.bookmarks:
+        return target, state.bookmarks[target]
+    raise DomainError("unknown key")
+
+
+def add_bookmark(state: State, key: str, directory: str) -> None:
+    if not key:
+        raise DomainError("empty key")
+    path = absolute_path(directory)
+    if not Path(path).exists():
+        raise DomainError("directory does not exist")
+    state.bookmarks[key] = path
+
+
+def remove_bookmark(state: State, target: str) -> None:
+    key, _ = parse_target(state, target)
+    del state.bookmarks[key]
+
+
+def clear_bookmarks(state: State) -> None:
+    state.bookmarks.clear()
+    state.history.clear()
+    state.pointer = -1
+
+
+def append_history(state: State, directory: str) -> None:
+    if state.pointer < len(state.history) - 1:
+        state.history = state.history[: state.pointer + 1]
+    state.history.append(directory)
+    state.pointer = len(state.history) - 1
+
+
+def move_history(state: State, steps: int) -> str:
+    if state.pointer == -1:
+        raise DomainError("history empty")
+    new_index = state.pointer + steps
+    if new_index < 0 or new_index >= len(state.history):
+        raise DomainError("history boundary")
+    state.pointer = new_index
+    return state.history[state.pointer]
+
+
+def current_path(state: State) -> Optional[str]:
+    if 0 <= state.pointer < len(state.history):
+        return state.history[state.pointer]
+    return None
+
+
+def prev_next(state: State) -> Tuple[Optional[str], Optional[str]]:
+    prev_path = None
+    next_path = None
+    if 0 <= state.pointer - 1 < len(state.history):
+        prev_path = state.history[state.pointer - 1]
+    if 0 <= state.pointer + 1 < len(state.history):
+        next_path = state.history[state.pointer + 1]
+    return prev_path, next_path
+
+
+def render_list(state: State) -> str:
+    if not state.bookmarks:
+        return "(no bookmarks)"
+    keys = sorted(state.bookmarks)
+    key_width = max(len(key) for key in keys)
+    index_width = len(str(len(keys)))
+    paths = [state.bookmarks[k] for k in keys]
+    # Adaptive width: allow 80 char display, allocate dynamic width to path column
+    term_width = 80
+    path_width = term_width - (index_width + key_width + 4)
+    if path_width < 20:
+        path_width = 20
+
+    def shorten(path: str) -> str:
+        if len(path) <= path_width:
+            return path
+        keep = path_width - 3
+        head = keep // 2
+        tail = keep - head
+        return f"{path[:head]}...{path[-tail:]}"
+
+    rows = []
+    for idx, key, path in zip(range(1, len(keys) + 1), keys, paths):
+        rows.append(f"{idx:>{index_width}}. {key:<{key_width}} {shorten(path)}")
+    return "\n".join(rows)
+
+
+def render_history(state: State, before: int, after: int) -> str:
+    if not state.history:
+        return "(history empty)"
+    start = max(0, state.pointer - before)
+    end = min(len(state.history), state.pointer + after + 1)
+    lines = []
+    for idx in range(start, end):
+        marker = "*" if idx == state.pointer else " "
+        entry = state.history[idx]
+        lines.append(f"{marker} {idx + 1:>3}: {entry}")
+    return "\n".join(lines)
+
+
+def handle_add(args: argparse.Namespace, state: State) -> int:
+    add_bookmark(state, args.key, args.directory)
+    save_state(state)
+    return 0
+
+
+def handle_list(args: argparse.Namespace, state: State) -> int:
+    print(render_list(state))
+    return 0
+
+
+def handle_rm(args: argparse.Namespace, state: State) -> int:
+    remove_bookmark(state, args.target)
+    save_state(state)
+    return 0
+
+
+def handle_clear(args: argparse.Namespace, state: State) -> int:
+    if not args.yes:
+        response = input("Clear all bookmarks and history? [y/N]: ")
+        if response.strip().lower() not in {"y", "yes"}:
+            print("Aborted.")
+            return 0
+    clear_bookmarks(state)
+    save_state(state)
+    return 0
+
+
+def ensure_valid_path(path: str) -> str:
+    resolved = absolute_path(path)
+    if not Path(resolved).exists():
+        raise DomainError("directory does not exist")
+    return resolved
+
+
+def handle_go(args: argparse.Namespace, state: State) -> int:
+    key, path = parse_target(state, args.target)
+    resolved = ensure_valid_path(path)
+    append_history(state, resolved)
+    save_state(state)
+    print(resolved)
+    return 0
+
+
+def handle_back(args: argparse.Namespace, state: State) -> int:
+    steps = args.steps
+    steps = -abs(steps)
+    path = ensure_valid_path(move_history(state, steps))
+    save_state(state)
+    print(path)
+    return 0
+
+
+def handle_fwd(args: argparse.Namespace, state: State) -> int:
+    steps = abs(args.steps)
+    path = ensure_valid_path(move_history(state, steps))
+    save_state(state)
+    print(path)
+    return 0
+
+
+def handle_hist(args: argparse.Namespace, state: State) -> int:
+    before = args.before if args.before is not None else 5
+    after = args.after if args.after is not None else 5
+    print(render_history(state, before, after))
+    return 0
+
+
+def handle_env(args: argparse.Namespace, state: State) -> int:
+    prev_path, next_path = prev_next(state)
+    prev_value = prev_path or ""
+    next_value = next_path or ""
+    print(f"PREV={prev_value}")
+    print(f"NEXT={next_value}")
+    return 0
+
+
+def build_parser() -> UsageArgumentParser:
+    parser = UsageArgumentParser(
+        prog="gdir",
+        description="Keyword-driven directory jumper with history support.",
+    )
+    parser.add_argument(
+        "--config-dir",
+        help="Override config directory (for testing)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_parser = subparsers.add_parser("add", help="Add a bookmark")
+    add_parser.add_argument("key")
+    add_parser.add_argument("directory")
+    add_parser.set_defaults(func=handle_add)
+
+    list_parser = subparsers.add_parser("list", help="List bookmarks")
+    list_parser.set_defaults(func=handle_list)
+
+    rm_parser = subparsers.add_parser("rm", help="Remove a bookmark by key or index")
+    rm_parser.add_argument("target")
+    rm_parser.set_defaults(func=handle_rm)
+
+    clear_parser = subparsers.add_parser("clear", help="Clear all data")
+    clear_parser.add_argument("--yes", action="store_true", help="Skip confirmation prompt")
+    clear_parser.set_defaults(func=handle_clear)
+
+    go_parser = subparsers.add_parser("go", help="Navigate to a bookmark by key or index")
+    go_parser.add_argument("target")
+    go_parser.set_defaults(func=handle_go)
+
+    back_parser = subparsers.add_parser("back", help="Move backward in history")
+    back_parser.add_argument("steps", nargs="?", type=int, default=1)
+    back_parser.set_defaults(func=handle_back)
+
+    fwd_parser = subparsers.add_parser("fwd", help="Move forward in history")
+    fwd_parser.add_argument("steps", nargs="?", type=int, default=1)
+    fwd_parser.set_defaults(func=handle_fwd)
+
+    hist_parser = subparsers.add_parser("hist", help="Show history near the current position")
+    hist_parser.add_argument("--before", type=int)
+    hist_parser.add_argument("--after", type=int)
+    hist_parser.set_defaults(func=handle_hist)
+
+    env_parser = subparsers.add_parser("env", help="Print export-friendly environment pairs")
+    env_parser.set_defaults(func=handle_env)
+
+    help_parser = subparsers.add_parser("help", help="Show help with examples")
+    help_parser.set_defaults(func=lambda args, state: print_help(parser))
+
+    return parser
+
+
+def print_help(parser: argparse.ArgumentParser) -> int:
+    parser.print_help()
+    print("\nExamples:")
+    print("  gdir add proj ~/work/project")
+    print("  cd \"$(gdir go proj)\"")
+    return 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.config_dir:
+        os.environ["XDG_CONFIG_HOME"] = str(Path(args.config_dir).expanduser().resolve())
+
+    try:
+        state = load_state()
+        func = getattr(args, "func", None)
+        if func is None:
+            raise DomainError("no command provided")
+        result = func(args, state)
+        if isinstance(result, int):
+            return result
+        return 0
+    except DomainError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+    except SystemExit:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        sys.stderr.write(f"Internal error: {exc}\n")
+        return 70
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/variants/A/tests/test_cli_smoke.py
+++ b/variants/A/tests/test_cli_smoke.py
@@ -1,0 +1,131 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CLI = [sys.executable, "-m", "gdir"]
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+
+
+def run_cli(args, env, input_text=None, check=True):
+    result = subprocess.run(
+        CLI + list(args),
+        input=input_text,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"Command {' '.join(args)} failed: {result.returncode}\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+    return result
+
+
+@pytest.fixture()
+def env(tmp_path):
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    env = os.environ.copy()
+    env["XDG_CONFIG_HOME"] = str(cfg)
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = str(SRC_DIR) + (os.pathsep + existing if existing else "")
+    return env
+
+
+def test_add_list_rm_clear(env, tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+
+    run_cli(["add", "one", str(first)], env)
+    run_cli(["add", "two", str(second)], env)
+
+    listed = run_cli(["list"], env)
+    assert "one" in listed.stdout
+    assert "two" in listed.stdout
+
+    run_cli(["rm", "1"], env)
+    listed = run_cli(["list"], env)
+    assert "one" not in listed.stdout
+    assert "two" in listed.stdout
+
+    run_cli(["clear", "--yes"], env)
+    listed = run_cli(["list"], env)
+    assert "(no bookmarks)" in listed.stdout
+
+
+def test_navigation_and_history(env, tmp_path):
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+
+    run_cli(["add", "a", str(alpha)], env)
+    run_cli(["add", "b", str(beta)], env)
+
+    go_a = run_cli(["go", "a"], env)
+    assert go_a.stdout.strip() == str(alpha.resolve())
+
+    go_b = run_cli(["go", "b"], env)
+    assert go_b.stdout.strip() == str(beta.resolve())
+
+    back = run_cli(["back"], env)
+    assert back.stdout.strip() == str(alpha.resolve())
+
+    fwd = run_cli(["fwd"], env)
+    assert fwd.stdout.strip() == str(beta.resolve())
+
+    bad = run_cli(["go", "z"], env, check=False)
+    assert bad.returncode == 2
+
+    too_far = run_cli(["back", "5"], env, check=False)
+    assert too_far.returncode == 2
+
+
+def test_history_persists_across_processes(env, tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+
+    run_cli(["add", "w", str(work)], env)
+    run_cli(["add", "o", str(other)], env)
+    run_cli(["go", "w"], env)
+    run_cli(["go", "o"], env)
+    run_cli(["back"], env)
+
+    resume = run_cli(["fwd"], env)
+    assert resume.stdout.strip() == str(other.resolve())
+
+
+def test_env_output(env, tmp_path):
+    base = tmp_path / "base"
+    extra = tmp_path / "extra"
+    base.mkdir()
+    extra.mkdir()
+
+    run_cli(["add", "base", str(base)], env)
+    run_cli(["add", "extra", str(extra)], env)
+    run_cli(["go", "base"], env)
+    run_cli(["go", "extra"], env)
+
+    back = run_cli(["back"], env)
+    assert back.stdout.strip() == str(base.resolve())
+
+    env_out = run_cli(["env"], env)
+    lines = env_out.stdout.strip().splitlines()
+    assert lines[0].startswith("PREV=")
+    assert lines[1].startswith("NEXT=")
+    assert lines[0].split("=", 1)[1] == ""
+    assert lines[1].split("=", 1)[1] == str(extra.resolve())
+
+
+def test_help_command(env):
+    help_result = run_cli(["help"], env)
+    assert "Examples" in help_result.stdout

--- a/variants/A/wrapper.sh
+++ b/variants/A/wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Example wrapper showing how to cd using gdir Variant A
+TARGET=$(gdir go "$1") || exit $?
+cd "$TARGET"

--- a/variants/B/README-Bias.md
+++ b/variants/B/README-Bias.md
@@ -1,0 +1,4 @@
+# Bias Choices
+
+- **FLAGS+JSONL+STATE** — Primary actions use terse flags, while persistence splits across JSONL files (bookmarks/history) plus a standalone pointer JSON. This emphasized the separation between append-friendly logs and small random-access metadata.
+- **ENV-RICH** — `gdir -e` emits PREV/NEXT and `GDIR_<KEY>` exports. Seeing every bookmark in the environment highlights the trade-off between convenience and verbosity, and it nudged the implementation toward deterministic key sanitization.

--- a/variants/B/README-variant.md
+++ b/variants/B/README-variant.md
@@ -1,0 +1,3 @@
+# Variant B
+
+Variant B delivers the same feature set through a flag-driven interface. Short flags keep frequent actions tight (`gdir -g proj`) and we still translate legacy subcommands for compatibility. Persistence leans on JSONL event files plus a dedicated pointer file, mirroring log-style durability while keeping the active index trivial to inspect or reset. The richer `-e` export adds `GDIR_<KEY>` variables alongside PREV/NEXT, making it easy to wire bookmarks straight into shell completions or prompts. History trimming and pointer writes are kept separate to highlight how the JSONL + state split works in practice.

--- a/variants/B/src/gdir.py
+++ b/variants/B/src/gdir.py
@@ -1,0 +1,350 @@
+import argparse
+import json
+import os
+import sys
+from collections import OrderedDict
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+CONFIG_DIR_NAME = "gdirB"
+BOOKMARKS_FILE = "bookmarks.jsonl"
+HISTORY_FILE = "history.jsonl"
+POINTER_FILE = "pointer.json"
+
+
+class UsageParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:  # pragma: no cover - delegated to argparse
+        self.print_usage(sys.stderr)
+        self.exit(64, f"{self.prog}: error: {message}\n")
+
+
+class DomainError(Exception):
+    pass
+
+
+def config_dir() -> Path:
+    base = os.environ.get("XDG_CONFIG_HOME")
+    if base:
+        root = Path(base)
+    else:
+        root = Path.home() / ".config"
+    return root / CONFIG_DIR_NAME
+
+
+def bookmarks_path() -> Path:
+    return config_dir() / BOOKMARKS_FILE
+
+
+def history_path() -> Path:
+    return config_dir() / HISTORY_FILE
+
+
+def pointer_path() -> Path:
+    return config_dir() / POINTER_FILE
+
+
+def ensure_dirs() -> None:
+    config_dir().mkdir(parents=True, exist_ok=True)
+
+
+def read_jsonl(path: Path) -> List[dict]:
+    if not path.exists():
+        return []
+    lines = []
+    for raw in path.read_text().splitlines():
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            lines.append(parsed)
+    return lines
+
+
+def write_jsonl(path: Path, rows: List[dict]) -> None:
+    ensure_dirs()
+    content = "\n".join(json.dumps(row, sort_keys=True) for row in rows)
+    path.write_text(content + ("\n" if content else ""))
+
+
+def load_bookmarks() -> "OrderedDict[str, str]":
+    items = OrderedDict()
+    for row in read_jsonl(bookmarks_path()):
+        key = row.get("key")
+        path = row.get("path")
+        if isinstance(key, str) and isinstance(path, str):
+            items[key] = path
+    return items
+
+
+def save_bookmarks(bookmarks: Dict[str, str]) -> None:
+    rows = [{"key": key, "path": path} for key, path in bookmarks.items()]
+    write_jsonl(bookmarks_path(), rows)
+
+
+def load_history() -> List[str]:
+    entries: List[str] = []
+    for row in read_jsonl(history_path()):
+        value = row.get("path")
+        if isinstance(value, str):
+            entries.append(value)
+    return entries
+
+
+def save_history(history: List[str]) -> None:
+    rows = [{"path": entry} for entry in history]
+    write_jsonl(history_path(), rows)
+
+
+def load_pointer() -> int:
+    path = pointer_path()
+    if not path.exists():
+        return -1
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return -1
+    if isinstance(data, dict) and isinstance(data.get("index"), int):
+        return data["index"]
+    return -1
+
+
+def save_pointer(index: int) -> None:
+    ensure_dirs()
+    pointer_path().write_text(json.dumps({"index": index}))
+
+
+def normalize_path(value: str) -> str:
+    return str(Path(value).expanduser().resolve())
+
+
+def ensure_directory(path: str) -> str:
+    resolved = normalize_path(path)
+    if not Path(resolved).exists():
+        raise DomainError("directory does not exist")
+    return resolved
+
+
+def interpret_target(bookmarks: Dict[str, str], target: str) -> Tuple[str, str]:
+    if target.isdigit():
+        index = int(target)
+        keys = sorted(bookmarks)
+        if index < 1 or index > len(keys):
+            raise DomainError("index out of range")
+        key = keys[index - 1]
+        return key, bookmarks[key]
+    if target in bookmarks:
+        return target, bookmarks[target]
+    raise DomainError("unknown key")
+
+
+def append_history(history: List[str], pointer: int, directory: str) -> Tuple[List[str], int]:
+    if pointer < len(history) - 1:
+        history = history[: pointer + 1]
+    history.append(directory)
+    pointer = len(history) - 1
+    return history, pointer
+
+
+def shift_history(history: List[str], pointer: int, delta: int) -> Tuple[str, int]:
+    if pointer == -1:
+        raise DomainError("history empty")
+    new_index = pointer + delta
+    if new_index < 0 or new_index >= len(history):
+        raise DomainError("history boundary")
+    return history[new_index], new_index
+
+
+def prev_next(history: List[str], pointer: int) -> Tuple[Optional[str], Optional[str]]:
+    prev_val = history[pointer - 1] if 0 <= pointer - 1 < len(history) else None
+    next_val = history[pointer + 1] if 0 <= pointer + 1 < len(history) else None
+    return prev_val, next_val
+
+
+def render_list(bookmarks: Dict[str, str]) -> str:
+    if not bookmarks:
+        return "(no bookmarks)"
+    lines = []
+    for idx, key in enumerate(sorted(bookmarks), start=1):
+        lines.append(f"{idx:>3}. {key:<15} {bookmarks[key]}")
+    return "\n".join(lines)
+
+
+def render_history(history: List[str], pointer: int, before: int, after: int) -> str:
+    if not history:
+        return "(history empty)"
+    start = max(0, pointer - before)
+    end = min(len(history), pointer + after + 1)
+    rows = []
+    for idx in range(start, end):
+        marker = "*" if idx == pointer else " "
+        rows.append(f"{marker} {idx + 1:>3}: {history[idx]}")
+    return "\n".join(rows)
+
+
+def export_env(bookmarks: Dict[str, str], history: List[str], pointer: int) -> str:
+    prev_val, next_val = prev_next(history, pointer)
+    lines = [f"PREV={prev_val or ''}", f"NEXT={next_val or ''}"]
+    for key, value in sorted(bookmarks.items()):
+        env_key = "GDIR_" + key.upper().replace("-", "_")
+        lines.append(f"{env_key}={value}")
+    return "\n".join(lines)
+
+
+def translate_legacy(argv: List[str]) -> List[str]:
+    if not argv:
+        return argv
+    command = argv[0]
+    mapping = {
+        "list": ["-l"],
+        "add": ["-a"] + argv[1:],
+        "rm": ["-r"] + argv[1:],
+        "clear": ["-C"] + argv[1:],
+        "go": ["-g"] + argv[1:],
+        "back": ["-b"] + argv[1:],
+        "fwd": ["-f"] + argv[1:],
+        "hist": ["-H"] + argv[1:],
+        "env": ["-e"] + argv[1:],
+        "help": ["-h"],
+    }
+    if command in mapping:
+        return mapping[command]
+    return argv
+
+
+def build_parser() -> UsageParser:
+    parser = UsageParser(
+        prog="gdir",
+        add_help=False,
+        description="Keyword bookmark jumper with history",
+    )
+    parser.add_argument("--config-dir")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("-l", "--list", action="store_true")
+    group.add_argument("-a", "--add", nargs=2, metavar=("KEY", "DIR"))
+    group.add_argument("-r", "--remove", metavar="TARGET")
+    group.add_argument("-C", "--clear", action="store_true")
+    group.add_argument("-g", "--go", metavar="TARGET")
+    group.add_argument("-b", "--back", nargs="?", const="1", metavar="N")
+    group.add_argument("-f", "--forward", nargs="?", const="1", metavar="N")
+    group.add_argument("-H", "--history", nargs="*")
+    group.add_argument("-e", "--env", action="store_true")
+    group.add_argument("-h", "--help", action="store_true")
+    parser.add_argument("--before", type=int)
+    parser.add_argument("--after", type=int)
+    parser.add_argument("-y", "--yes", action="store_true")
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+    argv = translate_legacy(list(argv))
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.config_dir:
+        os.environ["XDG_CONFIG_HOME"] = str(Path(args.config_dir).expanduser().resolve())
+
+    try:
+        bookmarks = load_bookmarks()
+        history = load_history()
+        pointer = load_pointer()
+
+        if args.help:
+            return print_help(parser)
+        if args.list:
+            print(render_list(bookmarks))
+            return 0
+        if args.add:
+            key, directory = args.add
+            if not key:
+                raise DomainError("empty key")
+            resolved = ensure_directory(directory)
+            bookmarks[key] = resolved
+            save_bookmarks(bookmarks)
+            return 0
+        if args.remove:
+            key, _ = interpret_target(bookmarks, args.remove)
+            del bookmarks[key]
+            save_bookmarks(bookmarks)
+            return 0
+        if args.clear:
+            if not args.yes:
+                response = input("Clear all bookmarks and history? [y/N]: ")
+                if response.strip().lower() not in {"y", "yes"}:
+                    print("Aborted.")
+                    return 0
+            bookmarks.clear()
+            history.clear()
+            pointer = -1
+            save_bookmarks(bookmarks)
+            save_history(history)
+            save_pointer(pointer)
+            return 0
+        if args.go:
+            key, directory = interpret_target(bookmarks, args.go)
+            resolved = ensure_directory(directory)
+            history, pointer = append_history(history, pointer, resolved)
+            save_history(history)
+            save_pointer(pointer)
+            print(resolved)
+            return 0
+        if args.back:
+            steps = int(args.back)
+            target, pointer = shift_history(history, pointer, -abs(steps))
+            resolved = ensure_directory(target)
+            save_pointer(pointer)
+            print(resolved)
+            return 0
+        if args.forward:
+            steps = int(args.forward)
+            target, pointer = shift_history(history, pointer, abs(steps))
+            resolved = ensure_directory(target)
+            save_pointer(pointer)
+            print(resolved)
+            return 0
+        if args.history is not None:
+            before = args.before if args.before is not None else 5
+            after = args.after if args.after is not None else 5
+            print(render_history(history, pointer, before, after))
+            return 0
+        if args.env:
+            print(export_env(bookmarks, history, pointer))
+            return 0
+    except DomainError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+    except SystemExit:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        sys.stderr.write(f"Internal error: {exc}\n")
+        return 70
+    return 0
+
+
+def print_help(parser: argparse.ArgumentParser) -> int:
+    usage = (
+        "Usage: gdir [options]\n"
+        "  -a KEY DIR   Add bookmark\n"
+        "  -g TARGET    Go to bookmark (key or index)\n"
+        "  -b [N]       Back N steps (default 1)\n"
+        "  -f [N]       Forward N steps\n"
+        "  -l           List bookmarks\n"
+        "  -H           Show history (--before/--after to adjust window)\n"
+        "  -e           Print env exports\n"
+        "  -C           Clear all data (use -y to confirm)\n"
+        "  -h           Show this help\n"
+    )
+    print(usage)
+    print("Examples:")
+    print("  gdir -a proj ~/src/project")
+    print("  cd \"$(gdir -g proj)\"")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/variants/B/tests/test_cli_smoke.py
+++ b/variants/B/tests/test_cli_smoke.py
@@ -1,0 +1,134 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CLI = [sys.executable, "-m", "gdir"]
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+
+
+def run_cli(args, env, input_text=None, check=True):
+    result = subprocess.run(
+        CLI + list(args),
+        input=input_text,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"Command {' '.join(args)} failed: {result.returncode}\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+    return result
+
+
+@pytest.fixture()
+def env(tmp_path):
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    env = os.environ.copy()
+    env["XDG_CONFIG_HOME"] = str(cfg)
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = str(SRC_DIR) + (os.pathsep + existing if existing else "")
+    return env
+
+
+def test_add_list_rm_clear(env, tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+
+    run_cli(["-a", "one", str(first)], env)
+    run_cli(["-a", "two", str(second)], env)
+
+    listed = run_cli(["-l"], env)
+    assert "one" in listed.stdout
+    assert "two" in listed.stdout
+
+    run_cli(["-r", "1"], env)
+    listed = run_cli(["-l"], env)
+    assert "one" not in listed.stdout
+    assert "two" in listed.stdout
+
+    run_cli(["-C", "-y"], env)
+    listed = run_cli(["-l"], env)
+    assert "(no bookmarks)" in listed.stdout
+
+
+def test_navigation_and_history(env, tmp_path):
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+
+    run_cli(["-a", "a", str(alpha)], env)
+    run_cli(["-a", "b", str(beta)], env)
+
+    go_a = run_cli(["-g", "a"], env)
+    assert go_a.stdout.strip() == str(alpha.resolve())
+
+    go_b = run_cli(["-g", "b"], env)
+    assert go_b.stdout.strip() == str(beta.resolve())
+
+    back = run_cli(["-b"], env)
+    assert back.stdout.strip() == str(alpha.resolve())
+
+    fwd = run_cli(["-f"], env)
+    assert fwd.stdout.strip() == str(beta.resolve())
+
+    bad = run_cli(["-g", "z"], env, check=False)
+    assert bad.returncode == 2
+
+    too_far = run_cli(["-b", "5"], env, check=False)
+    assert too_far.returncode == 2
+
+
+def test_history_persists_across_processes(env, tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+
+    run_cli(["-a", "w", str(work)], env)
+    run_cli(["-a", "o", str(other)], env)
+    run_cli(["-g", "w"], env)
+    run_cli(["-g", "o"], env)
+    run_cli(["-b"], env)
+
+    resume = run_cli(["-f"], env)
+    assert resume.stdout.strip() == str(other.resolve())
+
+
+def test_env_output(env, tmp_path):
+    base = tmp_path / "base"
+    extra = tmp_path / "extra"
+    base.mkdir()
+    extra.mkdir()
+
+    run_cli(["-a", "base", str(base)], env)
+    run_cli(["-a", "extra", str(extra)], env)
+    run_cli(["-g", "base"], env)
+    run_cli(["-g", "extra"], env)
+
+    back = run_cli(["-b"], env)
+    assert back.stdout.strip() == str(base.resolve())
+
+    env_out = run_cli(["-e"], env)
+    lines = env_out.stdout.strip().splitlines()
+    assert lines[0].startswith("PREV=")
+    assert lines[1].startswith("NEXT=")
+    exports = {line.split("=", 1)[0]: line.split("=", 1)[1] for line in lines}
+    assert exports["PREV"] == ""
+    assert exports["NEXT"] == str(extra.resolve())
+    assert exports["GDIR_BASE"] == str(base.resolve())
+    assert exports["GDIR_EXTRA"] == str(extra.resolve())
+
+
+def test_help_command(env):
+    help_result = run_cli(["-h"], env)
+    assert "Examples" in help_result.stdout

--- a/variants/B/wrapper.sh
+++ b/variants/B/wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Example wrapper showing how to cd using gdir Variant B
+TARGET=$(gdir -g "$1") || exit $?
+cd "$TARGET"


### PR DESCRIPTION
## Summary
- add variant A implementation of gdir using subcommands with single JSON persistence
- add variant B implementation of gdir using flag-driven interface with JSONL persistence and rich env exports

## Testing
- pytest -q variants/A/tests
- pytest -q variants/B/tests

------
https://chatgpt.com/codex/tasks/task_e_68f95aed8f648331a76d9306c0ffedeb