### PR TITLE
Add gdir variant with JSON-backed history

### DIFF
--- a/variants/current/README-Bias.md
+++ b/variants/current/README-Bias.md
@@ -1,0 +1,5 @@
+Biases applied:
+1. Prefer subcommands CLI and a single JSON file for persistence.
+3. Prefer minimal env export (PREV/NEXT only, no per-key exports).
+
+Rationale: Subcommands make the interface self-documenting and align with the project spec for keyword management, while a single JSON file keeps persistence easy to inspect. The minimal env export keeps shell integration predictable and avoids polluting the environment.

--- a/variants/current/README-variant.md
+++ b/variants/current/README-variant.md
@@ -1,0 +1,3 @@
+gdir keeps a single JSON state file under ~/.config/gdir/ that stores both keyword mappings and navigation history. The CLI uses subcommands (add, list, go, back, etc.) and prints absolute paths for movement commands so it can be wrapped by any shell. History persists across processes, with the pointer updated whenever go/back/fwd run. The env command emits simple PREV/NEXT exports suitable for eval.
+
+Trade-offs: storing everything in one JSON file is straightforward but offers limited concurrent safety; for this scope the simplicity outweighs potential race concerns. Confirming clear with a prompt avoids accidental wipes while still allowing automation via --yes.

--- a/variants/current/src/gdir.py
+++ b/variants/current/src/gdir.py
@@ -1,0 +1,317 @@
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+CONFIG_DIR_NAME = "gdir"
+STATE_FILE_NAME = "state.json"
+
+
+def config_dir() -> Path:
+    base = Path(os.path.expanduser("~")) / ".config" / CONFIG_DIR_NAME
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def state_path() -> Path:
+    return config_dir() / STATE_FILE_NAME
+
+
+@dataclass
+class Entry:
+    key: str
+    path: str
+
+
+@dataclass
+class State:
+    entries: List[Entry]
+    history: List[str]
+    history_index: int
+
+    @classmethod
+    def empty(cls) -> "State":
+        return cls(entries=[], history=[], history_index=-1)
+
+
+class CommandError(Exception):
+    def __init__(self, message: str, exit_code: int):
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+def load_state() -> State:
+    path = state_path()
+    if not path.exists():
+        return State.empty()
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise CommandError(f"Failed to read state: {exc}", 70)
+
+    entries = [Entry(**item) for item in data.get("entries", [])]
+    history = data.get("history", [])
+    history_index = data.get("history_index", -1)
+    if history_index >= len(history):
+        history_index = len(history) - 1
+    return State(entries=entries, history=history, history_index=history_index)
+
+
+def save_state(state: State) -> None:
+    path = state_path()
+    serialisable = {
+        "entries": [entry.__dict__ for entry in state.entries],
+        "history": state.history,
+        "history_index": state.history_index,
+    }
+    try:
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(serialisable, fh, indent=2)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise CommandError(f"Failed to write state: {exc}", 70)
+
+
+def resolve_selection(state: State, token: str) -> int:
+    for index, entry in enumerate(state.entries):
+        if entry.key == token:
+            return index
+    try:
+        numeric = int(token)
+    except ValueError:
+        raise CommandError(f"Unknown key or index: {token}", 2)
+    if numeric < 1 or numeric > len(state.entries):
+        raise CommandError(f"Index out of range: {token}", 2)
+    return numeric - 1
+
+
+def ensure_directory(path: str) -> str:
+    abs_path = os.path.abspath(os.path.expanduser(path))
+    if not os.path.isdir(abs_path):
+        raise CommandError(f"Directory does not exist: {path}", 2)
+    return abs_path
+
+
+def add_entry(state: State, key: str, directory: str) -> None:
+    abs_dir = ensure_directory(directory)
+    for entry in state.entries:
+        if entry.key == key:
+            entry.path = abs_dir
+            break
+    else:
+        state.entries.append(Entry(key=key, path=abs_dir))
+    save_state(state)
+
+
+def remove_entry(state: State, token: str) -> None:
+    index = resolve_selection(state, token)
+    del state.entries[index]
+    save_state(state)
+
+
+def clear_entries(state: State, *, confirm: bool) -> None:
+    if not confirm:
+        response = input("Type 'yes' to confirm: ").strip().lower()
+        if response != "yes":
+            print("Cancelled.")
+            return
+    state.entries.clear()
+    save_state(state)
+
+
+def select_entry(state: State, token: str) -> Entry:
+    index = resolve_selection(state, token)
+    return state.entries[index]
+
+
+def push_history(state: State, path: str) -> None:
+    if state.history_index < len(state.history) - 1:
+        state.history = state.history[: state.history_index + 1]
+    state.history.append(path)
+    state.history_index = len(state.history) - 1
+
+
+
+def move_history(state: State, steps: int) -> str:
+    target = state.history_index + steps
+    if target < 0 or target >= len(state.history):
+        raise CommandError("History boundary reached", 2)
+    state.history_index = target
+    path = state.history[target]
+    if not os.path.isdir(path):
+        raise CommandError(f"Directory does not exist: {path}", 2)
+    return path
+
+
+def handle_list(state: State) -> None:
+    if not state.entries:
+        print("No saved directories.")
+        return
+    width = len(str(len(state.entries)))
+    for idx, entry in enumerate(state.entries, start=1):
+        print(f"{str(idx).rjust(width)}  {entry.key}  {entry.path}")
+
+
+def handle_add(state: State, args: argparse.Namespace) -> None:
+    add_entry(state, args.key, args.directory)
+
+
+def handle_rm(state: State, args: argparse.Namespace) -> None:
+    remove_entry(state, args.target)
+
+
+def handle_clear(state: State, args: argparse.Namespace) -> None:
+    clear_entries(state, confirm=args.yes)
+
+
+def handle_go(state: State, args: argparse.Namespace) -> None:
+    entry = select_entry(state, args.target)
+    abs_path = ensure_directory(entry.path)
+    push_history(state, abs_path)
+    save_state(state)
+    print(abs_path)
+
+
+def handle_back(state: State, args: argparse.Namespace) -> None:
+    if not state.history:
+        raise CommandError("History is empty", 2)
+    steps = args.steps or 1
+    if steps < 1:
+        raise CommandError("Steps must be positive", 64)
+    path = move_history(state, -steps)
+    save_state(state)
+    print(path)
+
+
+def handle_fwd(state: State, args: argparse.Namespace) -> None:
+    if not state.history:
+        raise CommandError("History is empty", 2)
+    steps = args.steps or 1
+    if steps < 1:
+        raise CommandError("Steps must be positive", 64)
+    path = move_history(state, steps)
+    save_state(state)
+    print(path)
+
+
+def handle_hist(state: State, args: argparse.Namespace) -> None:
+    if not state.history:
+        print("History is empty.")
+        return
+    before = args.before if args.before is not None else 5
+    after = args.after if args.after is not None else 5
+    start = max(0, state.history_index - before)
+    end = min(len(state.history), state.history_index + after + 1)
+    width = len(str(len(state.history)))
+    for idx in range(start, end):
+        marker = "*" if idx == state.history_index else " "
+        path = state.history[idx]
+        print(f"{marker} {str(idx + 1).rjust(width)}  {path}")
+
+
+def handle_env(state: State) -> None:
+    prev_path = ""
+    next_path = ""
+    if state.history_index > 0:
+        prev_path = state.history[state.history_index - 1]
+    if 0 <= state.history_index < len(state.history) - 1:
+        next_path = state.history[state.history_index + 1]
+    print(f"export PREV=\"{prev_path}\"")
+    print(f"export NEXT=\"{next_path}\"")
+
+
+class Parser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:  # pragma: no cover - argparse behaviour
+        self.print_usage(sys.stderr)
+        self.exit(64, f"{self.prog}: error: {message}\n")
+
+
+def build_parser() -> Parser:
+    parser = Parser(
+        prog="gdir",
+        description="Keyword-based directory jumper with history.",
+        epilog=(
+            "Examples:\n"
+            "  gdir add proj ~/projects/sample\n"
+            "  cd \"$(gdir go proj)\""
+        ),
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("list", help="Show saved directories")
+
+    add_parser = subparsers.add_parser("add", help="Add or update a directory")
+    add_parser.add_argument("key")
+    add_parser.add_argument("directory")
+
+    rm_parser = subparsers.add_parser("rm", help="Remove a directory by key or index")
+    rm_parser.add_argument("target")
+
+    clear_parser = subparsers.add_parser("clear", help="Remove all saved directories")
+    clear_parser.add_argument("--yes", action="store_true", help="Confirm without prompt")
+
+    go_parser = subparsers.add_parser("go", help="Print directory path for navigation")
+    go_parser.add_argument("target")
+
+    back_parser = subparsers.add_parser("back", help="Move backward in history")
+    back_parser.add_argument("steps", nargs="?", type=int)
+
+    fwd_parser = subparsers.add_parser("fwd", help="Move forward in history")
+    fwd_parser.add_argument("steps", nargs="?", type=int)
+
+    hist_parser = subparsers.add_parser("hist", help="Show history around the current position")
+    hist_parser.add_argument("--before", type=int)
+    hist_parser.add_argument("--after", type=int)
+
+    subparsers.add_parser("env", help="Print PREV/NEXT export statements")
+
+    return parser
+
+
+def dispatch(state: State, args: argparse.Namespace) -> None:
+    command = args.command
+    if command == "list":
+        handle_list(state)
+    elif command == "add":
+        handle_add(state, args)
+    elif command == "rm":
+        handle_rm(state, args)
+    elif command == "clear":
+        handle_clear(state, args)
+    elif command == "go":
+        handle_go(state, args)
+    elif command == "back":
+        handle_back(state, args)
+    elif command == "fwd":
+        handle_fwd(state, args)
+    elif command == "hist":
+        handle_hist(state, args)
+    elif command == "env":
+        handle_env(state)
+    else:  # pragma: no cover - defensive
+        raise CommandError(f"Unknown command: {command}", 64)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    try:
+        args = parser.parse_args(argv)
+        state = load_state()
+        dispatch(state, args)
+        return 0
+    except CommandError as exc:
+        if exc.exit_code != 0 and str(exc):
+            print(str(exc), file=sys.stderr)
+        return exc.exit_code
+    except SystemExit as exc:  # pragma: no cover - forwarded
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"Internal error: {exc}", file=sys.stderr)
+        return 70
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/variants/current/tests/test_smoke.py
+++ b/variants/current/tests/test_smoke.py
@@ -1,0 +1,144 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+CLI = Path(__file__).resolve().parents[1] / "src" / "gdir.py"
+
+
+def run_cli(tmp_home, *args, input_text=None):
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_home)
+    result = subprocess.run(
+        [sys.executable, str(CLI), *args],
+        input=input_text.encode() if input_text else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        check=False,
+    )
+    return result
+
+
+def test_add_list_rm_clear(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    data_dir = home / "data"
+    data_dir.mkdir(parents=True)
+    other_dir = home / "other"
+    other_dir.mkdir()
+
+    result = run_cli(home, "add", "proj", str(data_dir))
+    assert result.returncode == 0, result.stderr.decode()
+
+    result = run_cli(home, "add", "docs", str(other_dir))
+    assert result.returncode == 0
+
+    result = run_cli(home, "list")
+    assert result.returncode == 0
+    output = result.stdout.decode().strip().splitlines()
+    assert output[0].endswith(f"proj  {data_dir}")
+    assert output[1].endswith(f"docs  {other_dir}")
+
+    result = run_cli(home, "rm", "1")
+    assert result.returncode == 0
+
+    result = run_cli(home, "list")
+    assert "proj" not in result.stdout.decode()
+
+    result = run_cli(home, "clear", "--yes")
+    assert result.returncode == 0
+
+    result = run_cli(home, "list")
+    assert "No saved directories" in result.stdout.decode()
+
+
+def test_go_back_fwd(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    dir_a = home / "a"
+    dir_a.mkdir()
+    dir_b = home / "b"
+    dir_b.mkdir()
+
+    run_cli(home, "add", "a", str(dir_a))
+    run_cli(home, "add", "b", str(dir_b))
+
+    result = run_cli(home, "go", "a")
+    assert result.returncode == 0
+    assert result.stdout.decode().strip() == str(dir_a)
+
+    result = run_cli(home, "go", "b")
+    assert result.stdout.decode().strip() == str(dir_b)
+
+    result = run_cli(home, "back")
+    assert result.stdout.decode().strip() == str(dir_a)
+
+    result = run_cli(home, "fwd")
+    assert result.stdout.decode().strip() == str(dir_b)
+
+    result = run_cli(home, "go", "missing")
+    assert result.returncode == 2
+
+
+def test_history_persistence(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    dir_a = home / "one"
+    dir_a.mkdir()
+    dir_b = home / "two"
+    dir_b.mkdir()
+
+    run_cli(home, "add", "one", str(dir_a))
+    run_cli(home, "add", "two", str(dir_b))
+
+    run_cli(home, "go", "one")
+    run_cli(home, "go", "two")
+
+    result = run_cli(home, "back")
+    assert result.stdout.decode().strip() == str(dir_a)
+
+    result = run_cli(home, "fwd")
+    assert result.stdout.decode().strip() == str(dir_b)
+
+    state_file = home / ".config" / "gdir" / "state.json"
+    assert state_file.exists()
+    data = json.loads(state_file.read_text())
+    assert data["history_index"] == 1
+    assert data["history"] == [str(dir_a), str(dir_b)]
+
+
+def test_env_output(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    first = home / "first"
+    first.mkdir()
+    second = home / "second"
+    second.mkdir()
+
+    run_cli(home, "add", "first", str(first))
+    run_cli(home, "add", "second", str(second))
+    run_cli(home, "go", "first")
+    run_cli(home, "go", "second")
+
+    result = run_cli(home, "env")
+    lines = result.stdout.decode().strip().splitlines()
+    assert lines[0] == f"export PREV=\"{first}\""
+    assert lines[1] == "export NEXT=\"\""
+
+    run_cli(home, "back")
+    result = run_cli(home, "env")
+    lines = result.stdout.decode().strip().splitlines()
+    assert lines[0] == "export PREV=\"\""
+    assert lines[1] == f"export NEXT=\"{second}\""
+
+
+def test_help(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    result = run_cli(home, "--help")
+    assert result.returncode == 0
+    text = result.stdout.decode()
+    assert "Examples:" in text
+    assert "gdir add" in text

--- a/variants/current/wrapper.sh
+++ b/variants/current/wrapper.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Example wrapper to integrate gdir with shell navigation
+cd "$(gdir go "$1")"


### PR DESCRIPTION
## Summary
- add a `gdir` CLI that stores keyword mappings and navigation history in a single JSON file
- implement smoke tests covering add/list/rm/clear, navigation, persistence, env, and help behavior
- document the variant biases and provide an example shell wrapper

## Testing
- pytest variants/current/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68f959c7dd848331809a07a94f9118b5