### PR TITLE
Implement manifest-driven mailbox sync workflow

### DIFF
--- a/src/ai_utils/FILE/tests/test_file_01.py
+++ b/src/ai_utils/FILE/tests/test_file_01.py
@@ -2,6 +2,7 @@ from unittest.mock import patch, mock_open
 
 import os
 import sys
+from pathlib import Path
 
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -81,17 +82,15 @@ def test_compare_manifest(tmp_path):
 
 # Test for pull_files_from_request
 def test_pull_files_from_request(tmp_path, monkeypatch):
-    from pathlib import Path
     import yaml
     import hashlib
 
-    # Setup paths
     test_from_chatty = tmp_path / "From_Chatty"
     received_dir = test_from_chatty / "received"
     test_from_chatty.mkdir()
-    monkeypatch.setattr(liaison, "FROM_CHATTY_DIR", str(test_from_chatty))
+    monkeypatch.setattr(liaison, "FROM_CHATTY_DIR", test_from_chatty, raising=False)
+    monkeypatch.setattr(liaison, "INBOX_DIR", Path("received"), raising=False)
 
-    # Create a file to be pulled
     file_rel = "pullme.txt"
     file_path = test_from_chatty / file_rel
     file_path.parent.mkdir(parents=True, exist_ok=True)
@@ -99,19 +98,82 @@ def test_pull_files_from_request(tmp_path, monkeypatch):
     file_path.write_bytes(content)
     file_hash = hashlib.sha256(content).hexdigest()
 
-    # Create request manifest file
-    request_manifest = {file_rel: file_hash}
+    request_manifest = {file_rel: {"sha256": file_hash}}
     request_file = tmp_path / "request.yml"
-    with open(request_file, "w") as f:
-        yaml.dump(request_manifest, f)
+    with open(request_file, "w", encoding="utf-8") as f:
+        yaml.safe_dump(request_manifest, f)
 
-    # Monkeypatch log_action to avoid file writes
     monkeypatch.setattr(liaison, "log_action", lambda *a, **k: None)
 
-    # Call the function
     liaison.pull_files_from_request(str(request_file))
 
-    # Assert file was copied
     pulled_file = received_dir / file_rel
     assert pulled_file.exists()
     assert pulled_file.read_bytes() == content
+
+
+def test_generate_manifest_file(tmp_path, monkeypatch):
+    import yaml
+
+    to_dir = tmp_path / "To_Chatty"
+    to_dir.mkdir()
+    (to_dir / "hello.txt").write_text("hi")
+    monkeypatch.setattr(liaison, "TO_CHATTY_DIR", to_dir, raising=False)
+    monkeypatch.setattr(liaison, "LOG_DIR", tmp_path / "logs", raising=False)
+    monkeypatch.setattr(liaison, "LOG_FILE", (tmp_path / "logs" / "file_log.txt"), raising=False)
+
+    manifest_path = liaison.generate_manifest_file(directory=to_dir)
+    assert manifest_path.exists()
+
+    manifest_data = yaml.safe_load(manifest_path.read_text())
+    assert "_meta" in manifest_data
+    assert manifest_data["_meta"]["file_count"] == 1
+    assert "hello.txt" in manifest_data
+    assert "sha256" in manifest_data["hello.txt"]
+
+
+def test_simulate_chatty_reply(tmp_path, monkeypatch):
+    to_dir = tmp_path / "To_Chatty"
+    from_dir = tmp_path / "From_Chatty"
+    to_dir.mkdir()
+    from_dir.mkdir()
+    monkeypatch.setattr(liaison, "TO_CHATTY_DIR", to_dir, raising=False)
+    monkeypatch.setattr(liaison, "FROM_CHATTY_DIR", from_dir, raising=False)
+    monkeypatch.setattr(liaison, "LOG_DIR", tmp_path / "logs", raising=False)
+    monkeypatch.setattr(liaison, "LOG_FILE", (tmp_path / "logs" / "file_log.txt"), raising=False)
+
+    (to_dir / "data.txt").write_text("payload")
+    liaison.generate_manifest_file(directory=to_dir)
+
+    liaison.simulate_chatty_reply()
+
+    copied = from_dir / "data.txt"
+    assert copied.exists()
+    assert copied.read_text() == "payload"
+
+
+def test_sync_from_chatty(tmp_path, monkeypatch, capsys):
+    from_dir = tmp_path / "From_Chatty"
+    inbox = tmp_path / "inbox"
+    from_dir.mkdir()
+    monkeypatch.setattr(liaison, "FROM_CHATTY_DIR", from_dir, raising=False)
+    monkeypatch.setattr(liaison, "LOG_DIR", tmp_path / "logs", raising=False)
+    monkeypatch.setattr(liaison, "LOG_FILE", (tmp_path / "logs" / "file_log.txt"), raising=False)
+
+    (from_dir / "alpha.txt").write_text("alpha")
+    liaison.generate_manifest_file(directory=from_dir)
+
+    liaison.sync_from_chatty(inbox=inbox, dry_run=True)
+    dry_output = capsys.readouterr().out
+    assert "Would Copy alpha.txt" in dry_output
+    assert not (inbox / "alpha.txt").exists()
+
+    liaison.sync_from_chatty(inbox=inbox)
+    capsys.readouterr()
+    copied_file = inbox / "alpha.txt"
+    assert copied_file.exists()
+    assert copied_file.read_text() == "alpha"
+
+    liaison.sync_from_chatty(inbox=inbox)
+    final_output = capsys.readouterr().out
+    assert "Inbox is up to date" in final_output


### PR DESCRIPTION
## Summary
- refactor liaison mailbox utilities to use manifest-driven sync operations backed by SHA256 metadata
- add CLI commands for generating manifests, simulating Chatty replies, and syncing inboxes (including two-way planning/apply)
- extend FILE liaison tests to cover manifest generation, simulation, and inbox synchronization workflows

## Testing
- pytest src/ai_utils/FILE/tests/test_file_01.py

------
https://chatgpt.com/codex/tasks/task_e_68fc68ff0c908331b6b04acc2a5b99e7